### PR TITLE
Improve private TTS feedback and add card audio polish in Coup

### DIFF
--- a/server/games/coup/game.py
+++ b/server/games/coup/game.py
@@ -147,6 +147,7 @@ class CoupGame(Game):
 
         # Play intro music
         self.play_music("game_coup/music.ogg")
+        self.play_sound(f"game_cards/shuffle{random.randint(1, 3)}.ogg")
 
         # Jolt bots
         BotHelper.jolt_bots(self, ticks=random.randint(10, 20))
@@ -927,6 +928,10 @@ class CoupGame(Game):
 
         self.passed_players.add(player.id)
 
+        user = self.get_user(player)
+        if user and not player.is_bot:
+            user.speak_l("coup-action-pass-confirmed", buffer="game")
+
         # Check if all other eligible players have passed
         alive = self.get_alive_players()
         eligible_count = 0
@@ -1063,9 +1068,16 @@ class CoupGame(Game):
                 if card.character == revealed_char:
                     self.deck.add(card)
                     self.deck.shuffle()
+                    self.play_sound(f"game_cards/discard{random.randint(1, 3)}.ogg")
                     claimer.influences.remove(card)
                     new_card = self.deck.draw()
                     claimer.influences.append(new_card)
+                    self.play_sound(f"game_cards/draw{random.randint(1, 4)}.ogg")
+                    if new_card and not claimer.is_bot:
+                        user = self.get_user(claimer)
+                        if user:
+                            new_card_name = Localization.get(user.locale, f"coup-card-{new_card.character.value}")
+                            user.speak_l("coup-drew-replacement-card", character=new_card_name, buffer="game")
                     break
 
             if self.turn_phase == "action_declared":
@@ -1197,8 +1209,12 @@ class CoupGame(Game):
             # Add 2 cards to hand, transition to exchange phase instantly
             card1 = self.deck.draw()
             card2 = self.deck.draw()
-            if card1: player.influences.append(card1)
-            if card2: player.influences.append(card2)
+            if card1:
+                player.influences.append(card1)
+                self.play_sound(f"game_cards/draw{random.randint(1, 4)}.ogg")
+            if card2:
+                player.influences.append(card2)
+                self.play_sound(f"game_cards/draw{random.randint(1, 4)}.ogg")
 
             self.turn_phase = "exchanging"
             self.interrupt_timer_ticks = 0
@@ -1225,6 +1241,7 @@ class CoupGame(Game):
         self.deck.add(card)
         self.deck.shuffle()
         coup_player.influences.remove(card)
+        self.play_sound(f"game_cards/discard{random.randint(1, 3)}.ogg")
 
         user = self.get_user(player)
         if user:
@@ -1272,6 +1289,7 @@ class CoupGame(Game):
         if len(live) == 1:
             # Only one left, auto-lose it
             self.play_sound(f"game_coup/chardestroy{random.randint(1, 2)}.ogg")
+            self.play_sound(f"game_cards/discard{random.randint(1, 3)}.ogg")
             player.reveal_influence(0)
             self._broadcast_card_message("coup-loses-influence", live[0].character, player=player.name)
             if player.is_dead:
@@ -1308,6 +1326,7 @@ class CoupGame(Game):
 
         sound_file = f"chardestroy{random.randint(1, 2)}.ogg"
         self.play_sound(f"game_coup/{sound_file}")
+        self.play_sound(f"game_cards/discard{random.randint(1, 3)}.ogg")
 
         char = coup_player.live_influences[idx].character
         coup_player.reveal_influence(idx)

--- a/server/locales/en/coup.ftl
+++ b/server/locales/en/coup.ftl
@@ -46,6 +46,9 @@ coup-claims-exchange = { $player } claims the Ambassador to exchange cards.
 coup-exchanges = { $player } draws 2 cards to exchange.
 coup-exchange-complete = { $player } has completed their exchange.
 
+coup-drew-replacement-card = You drew a { $character } as a replacement.
+coup-action-pass-confirmed = You passed.
+
 coup-waiting-for-reactions = Waiting for players to Challenge or Block...
 coup-player-eliminated = { $player } has lost all their influence and is eliminated from the game.
 coup-game-over = Game Over! { $winner } is the last survivor and wins the game!

--- a/server/locales/vi/coup.ftl
+++ b/server/locales/vi/coup.ftl
@@ -49,6 +49,9 @@ coup-claims-exchange = { $player } tuyên bố là Sứ giả để trao đổi 
 coup-exchanges = { $player } rút 2 lá bài để trao đổi.
 coup-exchange-complete = { $player } đã hoàn thành việc trao đổi bài.
 
+coup-drew-replacement-card = Bạn đã rút được lá { $character } để thay thế.
+coup-action-pass-confirmed = Bạn đã bỏ qua.
+
 coup-waiting-for-reactions = Đang chờ người chơi Thách thức hoặc Chặn...
 coup-player-eliminated = { $player } đã mất tất cả lá bài và bị loại khỏi cuộc chơi.
 coup-game-over = Trò chơi kết thúc! { $winner } là người cuối cùng còn sống sót và giành chiến thắng!


### PR DESCRIPTION
Improves the accessibility and general audio feedback of the Coup game.

1. **Replacement Card Notification:** The game now secretly announces the specific character card drawn as a replacement using a newly mapped localization string when a player successfully defends a challenge.
2. **Pass Confirmation:** Players now receive explicit, private audio confirmation ("You passed.") when they elect to pass during a challenge or block window, avoiding silent failure states.
3. **Card Event Audio:** The standard card-handling sound effects (draw, shuffle, discard) have been appropriately matched and integrated into respective events within the game (startup shuffling, drawing cards for Ambassador, returning cards, and influence loss).

---
*PR created automatically by Jules for task [10371685315481491332](https://jules.google.com/task/10371685315481491332) started by @Daoductrung*