### PR TITLE
Fix audio bugs caused by seamless table restart

### DIFF
--- a/server/game_utils/game_result_mixin.py
+++ b/server/game_utils/game_result_mixin.py
@@ -51,6 +51,15 @@ class GameResultMixin:
         self._last_game_result = result  # Store for menu restoration
         self._persist_result(result)
 
+        # Handle ambience stop/outro
+        if hasattr(self, "current_ambience_outro") and self.current_ambience_outro:
+            # Play the outro once (this will typically override/stop the loop in the client)
+            # However, to be safe, we can just play it as a regular sound
+            self.play_sound(self.current_ambience_outro)
+            self.stop_ambience()
+        else:
+            self.stop_ambience()
+
         # Show end screen
         if show_end_screen:
             self._show_end_screen(result)

--- a/server/game_utils/game_sound_mixin.py
+++ b/server/game_utils/game_sound_mixin.py
@@ -111,6 +111,7 @@ class GameSoundMixin:
     def play_ambience(self, loop: str, intro: str = "", outro: str = "") -> None:
         """Play ambient sound for all players."""
         self.current_ambience = loop
+        self.current_ambience_outro = outro
         for player in self.players:
             user = self.get_user(player)
             if user:
@@ -119,6 +120,7 @@ class GameSoundMixin:
     def stop_ambience(self) -> None:
         """Stop ambient sound for all players."""
         self.current_ambience = ""
+        self.current_ambience_outro = ""
         for player in self.players:
             user = self.get_user(player)
             if user:

--- a/server/games/base.py
+++ b/server/games/base.py
@@ -117,6 +117,7 @@ class Game(
     host: str = ""  # Username of the host
     current_music: str = ""  # Currently playing music track
     current_ambience: str = ""  # Currently playing ambience loop
+    current_ambience_outro: str = ""  # Outro for the currently playing ambience loop
     turn_index: int = 0  # Current turn index (serialized for persistence)
     turn_direction: int = 1  # Turn direction: 1 = forward, -1 = reverse
     turn_skip_count: int = 0  # Number of players to skip on next advance

--- a/server/tables/table.py
+++ b/server/tables/table.py
@@ -378,10 +378,17 @@ class Table(DataClassJSONMixin):
         if old_host != self.host:
              new_game.broadcast_l("table-new-host-promoted", buffer="system", player=self.host)
 
-        # 11. Mark old game as destroyed so ticks stop affecting it
+        # 11. Transfer scheduled sounds and sound scheduler tick from old game
+        new_game.scheduled_sounds = list(old_game.scheduled_sounds)
+        new_game.sound_scheduler_tick = old_game.sound_scheduler_tick
+
+        # 12. Play waiting lobby music
+        new_game.play_music("findgamemus.ogg")
+
+        # 13. Mark old game as destroyed so ticks stop affecting it
         old_game._destroyed = True
 
-        # 12. Sync status
+        # 14. Sync status
         self.status = "waiting"
 
     def save_and_close(self, username: str) -> None:


### PR DESCRIPTION
Fixes issues where game-specific music/ambience would continue playing after a game ends and transitions to the waiting lobby, as well as an issue where end-game victory sounds were swallowed.

* Added `current_ambience_outro` to `Game` and `GameSoundMixin` to track ambient outro loops.
* `GameResultMixin.finish_game()` now evaluates `current_ambience_outro`: it plays the outro once if it exists, and correctly stops the loop via `self.stop_ambience()`.
* `Table.reset_game()` explicitly plays the waiting lobby music (`findgamemus.ogg`).
* `Table.reset_game()` correctly copies `old_game.scheduled_sounds` and `old_game.sound_scheduler_tick` to the new game instance, ensuring sounds scheduled just before `finish_game()` fire correctly relative to their original timestamps instead of instantly or never.

---
*PR created automatically by Jules for task [3302997159439841134](https://jules.google.com/task/3302997159439841134) started by @Daoductrung*