### PR TITLE
fix: execute cli.py directly from sc.sh script dir

### DIFF
--- a/server/sc.sh
+++ b/server/sc.sh
@@ -182,9 +182,9 @@ create_user() {
     
     export PLAYAURAL_CLI_PW="$u_pass"
 
-    cd "$SERVER_DIR/.."
+    cd "$SERVER_DIR"
     echo "Running CLI (Package: $DIR_NAME) securely..."
-    sudo -u "$SERVICE_USER" -E $VENV_PYTHON -m ${DIR_NAME}.cli create-user "$u_name"
+    sudo -u "$SERVICE_USER" -E $VENV_PYTHON cli.py create-user "$u_name"
     
     unset PLAYAURAL_CLI_PW
     read -p "Press Enter to continue..."
@@ -201,8 +201,8 @@ reset_password() {
     
     export PLAYAURAL_CLI_PW="$u_pass"
 
-    cd "$SERVER_DIR/.."
-    sudo -u "$SERVICE_USER" -E $VENV_PYTHON -m ${DIR_NAME}.cli reset-password "$u_name"
+    cd "$SERVER_DIR"
+    sudo -u "$SERVICE_USER" -E $VENV_PYTHON cli.py reset-password "$u_name"
     
     unset PLAYAURAL_CLI_PW
     read -p "Press Enter to continue..."


### PR DESCRIPTION
Fix a "readonly database" error occurring during CLI commands in `sc.sh`. Previously, the script navigated to the parent directory (`..`) and executed the script via python `-m`. This caused the script to create/search for `playaural.db` in the repository root directory instead of the service's working directory, leading to a permission failure since the `playaural` service user did not have write access to the parent folder. 

`sc.sh` has been updated to `cd` dynamically to the exact directory where the script resides (`$SERVER_DIR`) and run `cli.py` directly as an executable, fixing the issue and aligning with flat-structure deployment patterns.

---
*PR created automatically by Jules for task [14614192588966759949](https://jules.google.com/task/14614192588966759949) started by @Daoductrung*