### PR TITLE
fix: standardise database filename to PlayAural.db

### DIFF
--- a/server/persistence/database.py
+++ b/server/persistence/database.py
@@ -56,7 +56,7 @@ class Database:
     Stores users and tables as specified in persistence.md.
     """
 
-    def __init__(self, db_path: str | Path = "playaural.db"):
+    def __init__(self, db_path: str | Path = "PlayAural.db"):
         self.db_path = Path(db_path)
         self._conn: sqlite3.Connection | None = None
 

--- a/server/sc.sh
+++ b/server/sc.sh
@@ -182,9 +182,9 @@ create_user() {
     
     export PLAYAURAL_CLI_PW="$u_pass"
 
-    cd "$SERVER_DIR/.."
+    cd "$SERVER_DIR"
     echo "Running CLI (Package: $DIR_NAME) securely..."
-    sudo -u "$SERVICE_USER" -E $VENV_PYTHON -m ${DIR_NAME}.cli create-user "$u_name"
+    sudo -u "$SERVICE_USER" -E $VENV_PYTHON cli.py create-user "$u_name"
     
     unset PLAYAURAL_CLI_PW
     read -p "Press Enter to continue..."
@@ -201,8 +201,8 @@ reset_password() {
     
     export PLAYAURAL_CLI_PW="$u_pass"
 
-    cd "$SERVER_DIR/.."
-    sudo -u "$SERVICE_USER" -E $VENV_PYTHON -m ${DIR_NAME}.cli reset-password "$u_name"
+    cd "$SERVER_DIR"
+    sudo -u "$SERVICE_USER" -E $VENV_PYTHON cli.py reset-password "$u_name"
     
     unset PLAYAURAL_CLI_PW
     read -p "Press Enter to continue..."


### PR DESCRIPTION
Fix a case-sensitivity issue where `cli.py` creates and connects to an empty database named `playaural.db` instead of the live systemd database `PlayAural.db`. This was caused by an inconsistent default parameter in `Database.__init__`.

The default database path in `Database` has been updated to `PlayAural.db` to match `server.py` and ensure the CLI tools accurately point to the main live database file across the entire application.