### PR TITLE
Fix missing _notify_admins Server method during registration

### DIFF
--- a/server/core/server.py
+++ b/server/core/server.py
@@ -295,6 +295,13 @@ PlayAural Server
                 continue  # Don't send broadcasts to unapproved users
             user.speak_l("dev-announcement-broadcast", buffer="system", dev=dev_name)
 
+    def _notify_admins(self, message_id: str, sound: str) -> None:
+        """Notify all online admins (trust level >= 2) with a message and sound."""
+        for user in self._users.values():
+            if user.trust_level >= 2:
+                user.speak_l(message_id)
+                user.play_sound(sound)
+
     async def _on_client_message(self, client: ClientConnection, packet: dict) -> None:
         """Handle incoming message from client."""
         packet_type = packet.get("type")


### PR DESCRIPTION
Fixes an `AttributeError` that occurred when a new user registered or requested approval, crashing the server because it attempted to call `self._notify_admins`.

**Changes:**
- Implemented `_notify_admins` in `server.py` to properly iterate over `self._users.values()` and identify admins/devs via `trust_level >= 2`.
- Validated correct server behavior and ensured all 370 tests continue to pass.

---
*PR created automatically by Jules for task [16005962043424948940](https://jules.google.com/task/16005962043424948940) started by @Daoductrung*