### PR TITLE
Fix `milebymile` stale teams

### DIFF
--- a/server/games/milebymile/game.py
+++ b/server/games/milebymile/game.py
@@ -1694,9 +1694,9 @@ class MileByMileGame(Game):
 
     def on_start(self) -> None:
         """Called when the game starts."""
-        # Ensure teams are set up (normally done in prestart_validate, but handle direct calls)
-        if not self._team_manager.teams:
-            self._setup_teams()
+        # Always set up teams unconditionally to ensure correct assignments,
+        # matching every other game.
+        self._setup_teams()
         self.status = "playing"
         self._sync_table_status()
         self.game_active = True


### PR DESCRIPTION
Fixes a bug in `milebymile` game where subsequent start attempts would reuse stale team assignments if `prestart_validate` failed previously. This is achieved by unconditionally running `self._setup_teams()` inside `on_start()`, rather than using an `if not self._team_manager.teams` guard, matching the behavior of every other game.

---
*PR created automatically by Jules for task [2508931016658775835](https://jules.google.com/task/2508931016658775835) started by @Daoductrung*