### PR TITLE
Add Five Field Kono board game

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ cd mobile_client && cmd /c npm run typecheck && npx expo start
 
 ## Core Architecture
 
-- `server/games/` currently registers 42 games. Categories are `cards`, `dice`,
+- `server/games/` currently registers 43 games. Categories are `cards`, `dice`,
   `board`, `poker`, `arcade`, and `misc`; user-facing category labels must be
   localized. The Play menu uses dynamic counts, not hardcoded category counts.
 - Games are `@dataclass` classes registered with `@register_game`, inherit from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -661,11 +661,11 @@ Mobile rules:
   language names; metadata complements it and does not replace it.
 
 ### Game Counts and Catalog
-The server currently registers **42 games**:
+The server currently registers **43 games**:
 - category ids are `cards`, `dice`, `board`, `poker`, `arcade`, and `misc`
 - the Play menu exposes a persisted category filter with dynamic per-category game counts
 - games usually expose one category through `get_category()`, while `get_categories()` supports future multi-category games
-- recent additions include `Metal Pipe`, `Nine`, `Senet`, `Cards Against Humanity`, `21`, `Age of Heroes`, and `UNO`
+- recent additions include `Nine`, `Senet`, `Cards Against Humanity`, `21`, `Age of Heroes`, `UNO`, and `Five Field Kono`
 
 ### Key Tech Stack
 - Python 3.11, `asyncio`, `websockets>=12.0`, `mashumaro`, `fluent-runtime`, `openskill`, `argon2-cffi`

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ PlayAural is designed so the full state of the platform can be followed without 
 
 ## Game Catalog
 
-PlayAural currently includes **42 games** across backend categories:
+PlayAural currently includes **43 games** across backend categories:
 
 - Card games such as Blackjack, Crazy Eights, UNO, Pusoy Dos, Tien Len, Scopa, Ninety Nine, Mile by Mile, Citadels, Coup, Dead Man's Deck, Dominos, Nine, 21, Cards Against Humanity, and Age of Heroes
 - Poker games such as Texas Hold'em, Five Card Draw, and Dead Man's Poker
 - Dice games such as Farkle, Bunko, Yahtzee, Pig, Left Center Right, Color Game, Toss Up, Tradeoff, Threes, and 1-4-24
-- Board games such as Chess, Battleship, Backgammon, Senet, Sorry!, Ludo, and Snakes and Ladders
+- Board games such as Chess, Battleship, Backgammon, Senet, Sorry!, Ludo, Snakes and Ladders, and Five Field Kono
 - Original arcade-style titles such as Battle, Chaos Bear, Light Turret, and Pirates of the Lost Seas
 - Miscellaneous games such as Rolling Balls and Metal Pipe
 

--- a/server/documentation/content/en/games/fivefieldkono.md
+++ b/server/documentation/content/en/games/fivefieldkono.md
@@ -1,0 +1,58 @@
+\*\*Five Field Kono\*\*
+
+Five Field Kono is a traditional Korean board game of quiet strategy. Its name comes from the five-by-five board it is played on. Two players each command seven stones and race to move them diagonally across the board into the positions where their opponent's stones began. There is no luck and no capturing — only careful maneuvering, and the constant danger of boxing your own stones into a corner they cannot escape.
+
+Five Field Kono is played by \*\*exactly two players\*\*.
+
+\*\*The Goal\*\*
+
+You win by moving all seven of your stones across the board to occupy the seven squares where your opponent's stones started. The first player to fill every one of those target squares wins. Because stones can only move forward and never capture, the game is a race of position: you must find a path for each stone while making sure you never trap yourself with no move to make.
+
+\*\*Board Layout\*\*
+
+The board is a grid of five rows by five columns. Columns are lettered \*\*A\*\* through \*\*E\*\* from left to right, and rows are numbered \*\*1\*\* through \*\*5\*\* from the near side to the far side. Every square is named by its column and row, such as A1, C3, or E5.
+
+The two roles are assigned randomly at the start, but Player 1 always moves first.
+
+\*\*Starting Position\*\*
+
+Each player begins with seven stones.
+
+\* \*\*Player 1 (south):\*\* the whole near row — A1, B1, C1, D1, E1 — plus the two outer squares of the second row, A2 and E2.
+\* \*\*Player 2 (north):\*\* the whole far row — A5, B5, C5, D5, E5 — plus the two outer squares of the fourth row, A4 and E4.
+
+Player 1's target is Player 2's seven starting squares, and Player 2's target is Player 1's seven starting squares.
+
+\*\*Moving Stones\*\*
+
+Moving is done in two steps. First select one of your own stones; the game confirms the stone and tells you how many moves it has. Then select the square you want to move it to. Selecting the same stone again clears the selection so you can choose a different one.
+
+The rules of movement are simple:
+
+\* A stone moves \*\*one square diagonally\*\*, and only \*\*forward\*\* — toward the opposite side of the board. Player 1 moves toward the higher-numbered rows; Player 2 moves toward the lower-numbered rows.
+\* The destination must be \*\*empty\*\*. Stones never capture and never share a square.
+\* Because each move is a single diagonal step, a stone always stays on squares of the same colour it started on.
+
+Most stones have two possible diagonals; a stone on the edge column has only one, and a stone with both diagonals blocked has none.
+
+\*\*Winning and Getting Stuck\*\*
+
+The moment all seven of your stones sit on your target squares, you win.
+
+There is one more way the game can end. Because stones only move forward and cannot jump or capture, a player can run out of moves entirely — every stone either blocked or already as far forward as it can go. \*\*If it is your turn and you have no legal move at all, you lose immediately.\*\* Guarding against this is the heart of the game: advancing carelessly can leave a stone stranded on an edge, or seal your own stones behind each other with nowhere to go.
+
+\*\*Keyboard Shortcuts\*\*
+
+\* \*\*Arrow keys:\*\* Move the cursor around the board to read each square.
+\* \*\*Enter:\*\* Select the stone under the cursor, then select a destination square to move.
+\* \*\*B:\*\* Review the whole board, one square at a time.
+\* \*\*P:\*\* Read your progress — how many of your stones have reached their target squares.
+\* \*\*L:\*\* Read the last move that was made.
+\* \*\*T:\*\* Check whose turn it is.
+
+\*\*Strategy Tips\*\*
+
+\* \*\*Never move without an escape.\*\* A single wrong step can leave a stone on an edge with no forward diagonal, and if that becomes your only stone able to move, you lose. Always keep a move in reserve.
+\* \*\*Keep your stones spread.\*\* Stones that bunch together block one another. A little space keeps your options open.
+\* \*\*Watch your opponent's dead ends too.\*\* Since running out of moves is a loss, steering the position so your opponent runs dry first is a winning plan in itself.
+\* \*\*Mind the colours.\*\* Each stone is bound to the squares of its own diagonal colour, so plan each stone's route to a target square of the matching colour from the very start.

--- a/server/documentation/content/vi/games/fivefieldkono.md
+++ b/server/documentation/content/vi/games/fivefieldkono.md
@@ -1,0 +1,58 @@
+\*\*Cờ Kono 5 Ô\*\*
+
+Cờ Kono 5 Ô là một trò chơi cờ truyền thống của Hàn Quốc, đề cao tư duy chiến thuật điềm tĩnh. Tên gọi bắt nguồn từ bàn cờ năm nhân năm mà trò chơi sử dụng. Hai người chơi, mỗi bên điều khiển bảy quân, đua nhau di chuyển quân theo đường chéo băng qua bàn cờ để chiếm lấy những ô mà quân của đối thủ đã bắt đầu. Không có yếu tố may rủi và không có ăn quân — chỉ có sự tính toán khéo léo, cùng nguy cơ thường trực là tự dồn quân mình vào thế bí không lối thoát.
+
+Cờ Kono 5 Ô dành cho \*\*đúng hai người chơi\*\*.
+
+\*\*Mục Tiêu\*\*
+
+Bạn thắng khi di chuyển cả bảy quân của mình băng qua bàn cờ để chiếm bảy ô nơi quân của đối thủ đã bắt đầu. Người đầu tiên lấp đầy tất cả các ô đích đó sẽ chiến thắng. Vì quân chỉ tiến về phía trước và không bao giờ ăn quân, đây là cuộc đua về vị trí: bạn phải tìm đường đi cho từng quân mà vẫn bảo đảm không bao giờ tự làm mình hết nước đi.
+
+\*\*Bố Cục Bàn Cờ\*\*
+
+Bàn cờ là một lưới gồm năm hàng và năm cột. Các cột được đánh dấu từ \*\*A\*\* đến \*\*E\*\* từ trái sang phải, còn các hàng được đánh số từ \*\*1\*\* đến \*\*5\*\* từ phía gần đến phía xa. Mỗi ô được gọi tên theo cột và hàng của nó, chẳng hạn A1, C3 hay E5.
+
+Vai trò của hai bên được chỉ định ngẫu nhiên khi bắt đầu, nhưng Người chơi 1 luôn đi trước.
+
+\*\*Vị Trí Ban Đầu\*\*
+
+Mỗi người chơi bắt đầu với bảy quân.
+
+\* \*\*Người chơi 1 (nam):\*\* toàn bộ hàng gần — A1, B1, C1, D1, E1 — cùng hai ô ngoài cùng của hàng thứ hai, A2 và E2.
+\* \*\*Người chơi 2 (bắc):\*\* toàn bộ hàng xa — A5, B5, C5, D5, E5 — cùng hai ô ngoài cùng của hàng thứ tư, A4 và E4.
+
+Đích của Người chơi 1 là bảy ô xuất phát của Người chơi 2, và đích của Người chơi 2 là bảy ô xuất phát của Người chơi 1.
+
+\*\*Di Chuyển Quân\*\*
+
+Việc di chuyển gồm hai bước. Trước tiên chọn một quân của bạn; trò chơi sẽ xác nhận quân đó và cho biết nó có bao nhiêu nước đi. Sau đó chọn ô bạn muốn đi tới. Chọn lại chính quân đó sẽ bỏ chọn để bạn có thể chọn quân khác.
+
+Luật di chuyển rất đơn giản:
+
+\* Quân đi \*\*một ô theo đường chéo\*\*, và chỉ \*\*tiến về phía trước\*\* — hướng về phía bên kia bàn cờ. Người chơi 1 tiến về các hàng số cao hơn; Người chơi 2 tiến về các hàng số thấp hơn.
+\* Ô đích phải \*\*trống\*\*. Quân không bao giờ ăn nhau và không bao giờ chung một ô.
+\* Vì mỗi nước là một bước chéo duy nhất, một quân luôn ở trên các ô cùng màu với ô nó xuất phát.
+
+Hầu hết các quân có hai đường chéo khả dĩ; một quân ở cột ngoài cùng chỉ có một, và một quân bị chặn cả hai đường chéo thì không có nước nào.
+
+\*\*Chiến Thắng và Thế Bí\*\*
+
+Ngay khi cả bảy quân của bạn nằm trên các ô đích, bạn thắng.
+
+Còn một cách nữa để ván cờ kết thúc. Vì quân chỉ tiến về phía trước và không thể nhảy hay ăn quân, một người chơi có thể hết sạch nước đi — mọi quân đều bị chặn hoặc đã đi xa hết mức có thể. \*\*Nếu đến lượt bạn mà bạn không còn nước đi hợp lệ nào, bạn thua ngay lập tức.\*\* Phòng tránh điều này chính là cốt lõi của trò chơi: tiến quân bất cẩn có thể để một quân mắc kẹt ở mép bàn, hoặc tự khóa các quân của bạn sau lưng nhau mà không còn chỗ đi.
+
+\*\*Phím Tắt\*\*
+
+\* \*\*Các phím mũi tên:\*\* Di chuyển con trỏ quanh bàn cờ để đọc từng ô.
+\* \*\*Enter:\*\* Chọn quân dưới con trỏ, rồi chọn ô đích để di chuyển.
+\* \*\*B:\*\* Xem toàn bộ bàn cờ, từng ô một.
+\* \*\*P:\*\* Đọc tiến độ của bạn — bao nhiêu quân đã tới ô đích.
+\* \*\*L:\*\* Đọc nước đi vừa rồi.
+\* \*\*T:\*\* Kiểm tra đang tới lượt ai.
+
+\*\*Mẹo Chiến Thuật\*\*
+
+\* \*\*Đừng đi khi không còn đường thoát.\*\* Một bước sai có thể để một quân mắc ở mép bàn không còn đường chéo tiến; nếu đó là quân duy nhất còn đi được, bạn thua. Luôn giữ sẵn một nước đi dự phòng.
+\* \*\*Giữ quân trải rộng.\*\* Các quân dồn cụm sẽ chặn lẫn nhau. Một chút khoảng cách giúp bạn giữ được nhiều lựa chọn.
+\* \*\*Cũng để ý ngõ cụt của đối thủ.\*\* Vì hết nước đi là thua, dồn thế cờ để đối thủ cạn nước trước là một kế hoạch thắng cuộc.
+\* \*\*Lưu ý màu ô.\*\* Mỗi quân bị ràng vào các ô cùng màu đường chéo của nó, vì vậy hãy hoạch định lộ trình của từng quân tới một ô đích cùng màu ngay từ đầu.

--- a/server/games/__init__.py
+++ b/server/games/__init__.py
@@ -46,6 +46,7 @@ from .humanitycards.game import HumanityCardsGame
 from .twentyone.game import TwentyOneGame
 from .ageofheroes.game import AgeOfHeroesGame
 from .uno.game import UnoGame
+from .fivefieldkono.game import FiveFieldKonoGame
 
 __all__ = [
     "Game",
@@ -94,4 +95,5 @@ __all__ = [
     "TwentyOneGame",
     "AgeOfHeroesGame",
     "UnoGame",
+    "FiveFieldKonoGame",
 ]

--- a/server/games/fivefieldkono/__init__.py
+++ b/server/games/fivefieldkono/__init__.py
@@ -1,0 +1,1 @@
+"""Five Field Kono game package."""

--- a/server/games/fivefieldkono/bot.py
+++ b/server/games/fivefieldkono/bot.py
@@ -1,12 +1,114 @@
-"""Bot AI for Five Field Kono (stub — real implementation in a later task)."""
+"""Bot AI for Five Field Kono — depth-limited negamax."""
 
 from __future__ import annotations
 
+import copy
 from typing import TYPE_CHECKING
+
+from ...game_utils.grid_mixin import grid_cell_id
+from .moves import (
+    Move,
+    apply_move,
+    generate_legal_moves,
+    has_any_legal_move,
+    is_winner,
+)
+from .state import (
+    FORWARD_DROW,
+    TARGET_CELLS,
+    FiveFieldKonoState,
+    cell_rowcol,
+    opponent_num,
+)
 
 if TYPE_CHECKING:
     from .game import FiveFieldKonoGame, FiveFieldKonoPlayer
 
+SEARCH_DEPTH = 4
+WIN_SCORE = 100_000
+
 
 def bot_think(game: "FiveFieldKonoGame", player: "FiveFieldKonoPlayer") -> str | None:
-    return None
+    if game.state.current_player_num != player.player_num:
+        return None
+    selected = game.selected_square.get(player.id)
+    if selected is not None:
+        # Second click: play the stored destination for the selected source.
+        dest = game.bot_move_targets.get(player.id)
+        if dest is None:
+            best = choose_move(game.state, player.player_num)
+            if best is None:
+                return None
+            dest = best.destination
+        row, col = cell_rowcol(dest)
+        return grid_cell_id(row, col)
+    best = choose_move(game.state, player.player_num)
+    if best is None:
+        return None
+    game.bot_move_targets[player.id] = best.destination
+    row, col = cell_rowcol(best.source)
+    return grid_cell_id(row, col)
+
+
+def choose_move(state: FiveFieldKonoState, player_num: int) -> Move | None:
+    moves = generate_legal_moves(state, player_num)
+    if not moves:
+        return None
+    best_move = moves[0]
+    best_score = float("-inf")
+    for move in moves:
+        child = copy.deepcopy(state)
+        apply_move(child, move)
+        score = -_negamax(
+            child, opponent_num(player_num), SEARCH_DEPTH - 1,
+            float("-inf"), float("inf"),
+        )
+        if score > best_score:
+            best_score = score
+            best_move = move
+    return best_move
+
+
+def _negamax(state, player_num, depth, alpha, beta) -> float:
+    prev = opponent_num(player_num)
+    if is_winner(state, prev):
+        return -WIN_SCORE  # the player who just moved already won
+    if not has_any_legal_move(state, player_num):
+        return -WIN_SCORE  # side to move is stuck -> loses
+    if depth <= 0:
+        return _evaluate(state, player_num)
+    value = float("-inf")
+    for move in generate_legal_moves(state, player_num):
+        child = copy.deepcopy(state)
+        apply_move(child, move)
+        value = max(
+            value,
+            -_negamax(child, opponent_num(player_num), depth - 1, -beta, -alpha),
+        )
+        alpha = max(alpha, value)
+        if alpha >= beta:
+            break
+    return value
+
+
+def _evaluate(state, player_num: int) -> float:
+    """Positive = good for `player_num`. Progress toward targets minus opp."""
+    return _side_progress(state, player_num) - _side_progress(
+        state, opponent_num(player_num)
+    )
+
+
+def _side_progress(state, num: int) -> float:
+    targets = TARGET_CELLS[num]
+    drow = FORWARD_DROW[num]
+    score = 0.0
+    for idx, piece in enumerate(state.board):
+        if piece is None or piece.owner_num != num:
+            continue
+        if idx in targets:
+            score += 20.0
+            continue
+        row, _ = cell_rowcol(idx)
+        # Forward progress: rows advanced toward the goal edge.
+        score += row if drow > 0 else (4 - row)
+    return score

--- a/server/games/fivefieldkono/bot.py
+++ b/server/games/fivefieldkono/bot.py
@@ -1,0 +1,12 @@
+"""Bot AI for Five Field Kono (stub — real implementation in a later task)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .game import FiveFieldKonoGame, FiveFieldKonoPlayer
+
+
+def bot_think(game: "FiveFieldKonoGame", player: "FiveFieldKonoPlayer") -> str | None:
+    return None

--- a/server/games/fivefieldkono/game.py
+++ b/server/games/fivefieldkono/game.py
@@ -355,6 +355,15 @@ class FiveFieldKonoGame(GridGameMixin, Game):
         self.broadcast_sound(SOUND_WIN)
         self.finish_game()
 
+    # ---- turn action set (board cells + navigation/select) ----
+    def create_turn_action_set(self, player: FiveFieldKonoPlayer) -> ActionSet:
+        action_set = ActionSet(name="turn")
+        for action in self.build_grid_actions(player):
+            action_set.add(action)
+        for action in self.build_grid_nav_actions():
+            action_set.add(action)
+        return action_set
+
     # ---- info actions ----
     def create_standard_action_set(self, player: Player) -> ActionSet:
         action_set = super().create_standard_action_set(player)

--- a/server/games/fivefieldkono/game.py
+++ b/server/games/fivefieldkono/game.py
@@ -1,0 +1,198 @@
+"""Five Field Kono game for PlayAural."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+
+from ..base import Game, GameOptions, Player
+from ..registry import register_game
+from ...game_utils.actions import Visibility
+from ...game_utils.bot_helper import BotHelper
+from ...game_utils.grid_mixin import GridCursor, GridGameMixin
+from ...messages.localization import Localization
+from .bot import bot_think
+from .moves import legal_destinations
+from .state import (
+    FiveFieldKonoState,
+    build_initial_state,
+    cell_index,
+    cell_rowcol,
+)
+
+
+@dataclass
+class FiveFieldKonoOptions(GameOptions):
+    pass
+
+
+@dataclass
+class FiveFieldKonoPlayer(Player):
+    player_num: int = 0  # 1 or 2
+
+
+@register_game
+@dataclass
+class FiveFieldKonoGame(GridGameMixin, Game):
+    """Five Field Kono — 5x5 diagonal race."""
+
+    relevant_preferences = ["brief_announcements"]
+
+    players: list[FiveFieldKonoPlayer] = field(default_factory=list)
+    options: FiveFieldKonoOptions = field(default_factory=FiveFieldKonoOptions)
+    state: FiveFieldKonoState = field(default_factory=FiveFieldKonoState)
+
+    selected_square: dict[str, int] = field(default_factory=dict)
+    bot_move_targets: dict[str, int] = field(default_factory=dict)
+    last_move: list[int] = field(default_factory=list)
+    winner_num: int = 0
+    win_reason: str = ""  # "" | "completed" | "stuck"
+    winner_name: str | None = None
+
+    grid_rows: int = 5
+    grid_cols: int = 5
+    grid_row_labels: list[str] = field(
+        default_factory=lambda: ["1", "2", "3", "4", "5"]
+    )
+    grid_col_labels: list[str] = field(default_factory=lambda: list("ABCDE"))
+    grid_cursors: dict[str, GridCursor] = field(default_factory=dict)
+
+    # ---- metadata ----
+    @classmethod
+    def get_name(cls) -> str:
+        return "Five Field Kono"
+
+    @classmethod
+    def get_type(cls) -> str:
+        return "fivefieldkono"
+
+    @classmethod
+    def get_category(cls) -> str:
+        return "board"
+
+    @classmethod
+    def get_min_players(cls) -> int:
+        return 2
+
+    @classmethod
+    def get_max_players(cls) -> int:
+        return 2
+
+    @classmethod
+    def get_supported_leaderboards(cls) -> list[str]:
+        return ["wins", "rating", "games_played"]
+
+    def create_player(
+        self, player_id: str, name: str, is_bot: bool = False
+    ) -> FiveFieldKonoPlayer:
+        return FiveFieldKonoPlayer(id=player_id, name=name, is_bot=is_bot)
+
+    # ---- helpers ----
+    def _player_locale(self, player: Player) -> str:
+        user = self.get_user(player)
+        return user.locale if user else "en"
+
+    def _get_player_by_num(self, num: int) -> FiveFieldKonoPlayer | None:
+        for p in self.get_active_players():
+            if isinstance(p, FiveFieldKonoPlayer) and p.player_num == num:
+                return p
+        return None
+
+    def _as_kono_player(self, player: Player) -> FiveFieldKonoPlayer | None:
+        return player if isinstance(player, FiveFieldKonoPlayer) else None
+
+    def _coord(self, index: int) -> str:
+        row, col = cell_rowcol(index)
+        return self._grid_cell_coordinate(row, col)
+
+    # ---- lifecycle ----
+    def on_start(self) -> None:
+        active = self.get_active_players()
+        if len(active) != 2:
+            return
+        self.status = "playing"
+        self.game_active = True
+        self.round = 1
+        self._init_grid()
+
+        if random.random() < 0.5:  # nosec B311
+            active[0].player_num, active[1].player_num = 1, 2
+        else:
+            active[0].player_num, active[1].player_num = 2, 1
+
+        p1 = self._get_player_by_num(1)
+        p2 = self._get_player_by_num(2)
+        self.state = build_initial_state(p1.id, p2.id)
+
+        self._team_manager.team_mode = "individual"
+        self._team_manager.setup_teams([p.name for p in active])
+
+        self.set_turn_players([p1, p2], reset_index=True)
+        self.current_player = p1
+        self.state.current_player_num = 1
+
+        self.broadcast_l(
+            "ffk-game-started",
+            buffer="game",
+            p1=p1.name,
+            p2=p2.name,
+            first=p1.name,
+        )
+        self.refresh_menus()
+        BotHelper.jolt_bots(self, ticks=random.randint(4, 8))
+
+    def on_tick(self) -> None:
+        super().on_tick()
+        self.process_scheduled_sounds()
+        if not self.game_active:
+            return
+        BotHelper.on_tick(self)
+
+    def bot_think(self, player: FiveFieldKonoPlayer) -> str | None:
+        return bot_think(self, player)
+
+    # ---- grid rendering ----
+    def get_cell_label(self, row: int, col: int, player: Player, locale: str) -> str:
+        index = cell_index(row, col)
+        coord = self._grid_cell_coordinate(row, col)
+        piece = self.state.board[index]
+        kp = self._as_kono_player(player)
+        selected = self.selected_square.get(player.id) if kp else None
+
+        if piece is None:
+            label = Localization.get(locale, "ffk-cell-empty", coord=coord)
+        elif kp and piece.owner_id == player.id:
+            label = Localization.get(locale, "ffk-cell-own", coord=coord)
+        else:
+            owner = self._get_player_by_num(piece.owner_num)
+            label = Localization.get(
+                locale,
+                "ffk-cell-opponent",
+                coord=coord,
+                owner=owner.name if owner else "?",
+            )
+
+        if selected == index:
+            return Localization.get(locale, "ffk-cell-selected", label=label)
+        if (
+            kp
+            and self.current_player is not None
+            and player.id == self.current_player.id
+            and selected is not None
+            and piece is None
+            and index in legal_destinations(self.state.board, selected, kp.player_num)
+        ):
+            return Localization.get(locale, "ffk-cell-move-target", coord=coord)
+        return label
+
+    def is_grid_cell_enabled(self, player: Player, row: int, col: int) -> str | None:
+        if self.status != "playing":
+            return "action-not-playing"
+        if player.is_spectator:
+            return "action-spectator"
+        return None
+
+    def is_grid_cell_hidden(self, player: Player, row: int, col: int) -> Visibility:
+        if self.status != "playing":
+            return Visibility.HIDDEN
+        return Visibility.VISIBLE

--- a/server/games/fivefieldkono/game.py
+++ b/server/games/fivefieldkono/game.py
@@ -9,16 +9,33 @@ from ..base import Game, GameOptions, Player
 from ..registry import register_game
 from ...game_utils.actions import Visibility
 from ...game_utils.bot_helper import BotHelper
-from ...game_utils.grid_mixin import GridCursor, GridGameMixin
+from ...game_utils.grid_mixin import GridCursor, GridGameMixin, grid_cell_id
 from ...messages.localization import Localization
 from .bot import bot_think
-from .moves import legal_destinations
+from .moves import (
+    Move,
+    apply_move,
+    has_any_legal_move,
+    is_winner,
+    legal_destinations,
+)
 from .state import (
+    PIECES_PER_PLAYER,
+    TARGET_CELLS,
     FiveFieldKonoState,
     build_initial_state,
     cell_index,
     cell_rowcol,
+    opponent_num,
+    player_piece_cells,
 )
+
+
+SOUND_PICKUP = "game_chess/pickup.ogg"
+SOUND_SETDOWN = "game_chess/setdown.ogg"
+SOUND_MOVE = "game_squares/step1.ogg"
+SOUND_TURN = "game_squares/begin turn.ogg"
+SOUND_WIN = "game_pig/win.ogg"
 
 
 @dataclass
@@ -196,3 +213,143 @@ class FiveFieldKonoGame(GridGameMixin, Game):
         if self.status != "playing":
             return Visibility.HIDDEN
         return Visibility.VISIBLE
+
+    # ---- interaction ----
+    def on_grid_select(self, player: Player, row: int, col: int) -> None:
+        if self.status != "playing":
+            return
+        kp = self._as_kono_player(player)
+        index = cell_index(row, col)
+        if (
+            kp
+            and not kp.is_spectator
+            and self.winner_num == 0
+            and self.current_player is not None
+            and player.id == self.current_player.id
+            and self.state.current_player_num == kp.player_num
+        ):
+            self._handle_select(kp, index)
+            return
+        self._announce_cell(player, index)
+
+    def _announce_cell(self, player: Player, index: int) -> None:
+        user = self.get_user(player)
+        if not user:
+            return
+        piece = self.state.board[index]
+        coord = self._coord(index)
+        if piece is None:
+            user.speak_l("ffk-cell-empty", buffer="game", coord=coord)
+        elif piece.owner_id == player.id:
+            user.speak_l("ffk-cell-own", buffer="game", coord=coord)
+        else:
+            owner = self._get_player_by_num(piece.owner_num)
+            user.speak_l(
+                "ffk-cell-opponent",
+                buffer="game",
+                coord=coord,
+                owner=owner.name if owner else "?",
+            )
+
+    def _handle_select(self, player: FiveFieldKonoPlayer, index: int) -> None:
+        user = self.get_user(player)
+        if not user:
+            return
+        piece = self.state.board[index]
+        selected = self.selected_square.get(player.id)
+
+        # Clicking the already-selected piece clears the selection.
+        if selected is not None and selected == index:
+            self.selected_square.pop(player.id, None)
+            user.play_sound(SOUND_SETDOWN)
+            user.speak_l("ffk-selection-cleared", buffer="game")
+            self.refresh_menus(player)
+            return
+
+        # Select a piece, or switch the selection to another own piece.
+        if selected is None or (piece is not None and piece.owner_id == player.id):
+            if piece is None or piece.owner_id != player.id:
+                user.speak_l("ffk-select-own-piece", buffer="game")
+                return
+            dests = legal_destinations(self.state.board, index, player.player_num)
+            if not dests:
+                user.speak_l("ffk-piece-no-moves", buffer="game")
+                return
+            self.selected_square[player.id] = index
+            user.play_sound(SOUND_PICKUP)
+            user.speak_l(
+                "ffk-piece-selected",
+                buffer="game",
+                coord=self._coord(index),
+                count=len(dests),
+            )
+            row, col = cell_rowcol(index)
+            self.request_menu_focus(player, grid_cell_id(row, col))
+            self.refresh_menus(player)
+            return
+
+        if index not in legal_destinations(
+            self.state.board, selected, player.player_num
+        ):
+            user.play_sound(SOUND_SETDOWN)
+            user.speak_l("ffk-illegal-move", buffer="game")
+            self.refresh_menus(player)
+            return
+
+        self._commit_move(player, Move(source=selected, destination=index))
+
+    def _commit_move(self, player: FiveFieldKonoPlayer, move: Move) -> None:
+        from_coord = self._coord(move.source)
+        to_coord = self._coord(move.destination)
+        self.last_move = [move.source, move.destination]
+        apply_move(self.state, move)
+        self.selected_square.pop(player.id, None)
+        self.bot_move_targets.pop(player.id, None)
+        self.broadcast_sound(SOUND_MOVE)
+        self.broadcast_personal_l(
+            player,
+            "ffk-move-you",
+            "ffk-move-other",
+            buffer="game",
+            **{"from": from_coord, "to": to_coord},
+        )
+        if is_winner(self.state, player.player_num):
+            self.win_reason = "completed"
+            self._handle_win(player)
+            return
+        self._end_turn(player)
+
+    def _end_turn(self, mover: FiveFieldKonoPlayer) -> None:
+        opp_num = opponent_num(mover.player_num)
+        opp = self._get_player_by_num(opp_num)
+        self.state.current_player_num = opp_num
+        if opp:
+            self.current_player = opp
+        # Stuck rule: opponent with no legal move at turn start loses.
+        if not has_any_legal_move(self.state, opp_num):
+            self.win_reason = "stuck"
+            self._handle_win(mover)
+            return
+        self.announce_turn(turn_sound=SOUND_TURN)
+        self.refresh_menus()
+        BotHelper.jolt_bots(self, ticks=random.randint(3, 6))
+
+    def _handle_win(self, winner: FiveFieldKonoPlayer) -> None:
+        self.winner_num = winner.player_num
+        self.winner_name = winner.name
+        if self.win_reason == "stuck":
+            self.broadcast_personal_l(
+                winner,
+                "ffk-win-stuck-you",
+                "ffk-win-stuck-other",
+                buffer="game",
+            )
+        else:
+            self.broadcast_personal_l(
+                winner,
+                "ffk-win-you",
+                "ffk-win-other",
+                buffer="game",
+            )
+        self.broadcast_sound(SOUND_WIN)
+        self.finish_game()

--- a/server/games/fivefieldkono/game.py
+++ b/server/games/fivefieldkono/game.py
@@ -7,10 +7,11 @@ from dataclasses import dataclass, field
 
 from ..base import Game, GameOptions, Player
 from ..registry import register_game
-from ...game_utils.actions import Visibility
+from ...game_utils.actions import Action, ActionSet, Visibility
 from ...game_utils.bot_helper import BotHelper
 from ...game_utils.grid_mixin import GridCursor, GridGameMixin, grid_cell_id
 from ...messages.localization import Localization
+from ...ui.keybinds import KeybindState
 from .bot import bot_think
 from .moves import (
     Move,
@@ -353,3 +354,122 @@ class FiveFieldKonoGame(GridGameMixin, Game):
             )
         self.broadcast_sound(SOUND_WIN)
         self.finish_game()
+
+    # ---- info actions ----
+    def create_standard_action_set(self, player: Player) -> ActionSet:
+        action_set = super().create_standard_action_set(player)
+        locale = self._player_locale(player)
+        user = self.get_user(player)
+        info = [
+            ("check_board", "ffk-check-board", "_action_check_board"),
+            ("check_progress", "ffk-check-progress", "_action_check_progress"),
+            ("check_last_move", "ffk-check-last-move", "_action_check_last_move"),
+        ]
+        for action_id, label_key, handler in info:
+            action_set.add(
+                Action(
+                    id=action_id,
+                    label=Localization.get(locale, label_key),
+                    handler=handler,
+                    is_enabled="_is_info_enabled",
+                    is_hidden="_is_touch_info_hidden",
+                    include_spectators=True,
+                )
+            )
+        if self.is_touch_client(user):
+            self._order_touch_standard_actions(
+                action_set,
+                [
+                    "check_board",
+                    "check_progress",
+                    "check_last_move",
+                    "whose_turn",
+                    "whos_at_table",
+                ],
+            )
+        return action_set
+
+    def setup_keybinds(self) -> None:
+        super().setup_keybinds()
+        self.setup_grid_keybinds()
+        self.define_keybind(
+            "b",
+            Localization.get("en", "ffk-check-board"),
+            ["check_board"],
+            state=KeybindState.ACTIVE,
+            include_spectators=True,
+        )
+        self.define_keybind(
+            "p",
+            Localization.get("en", "ffk-check-progress"),
+            ["check_progress"],
+            state=KeybindState.ACTIVE,
+            include_spectators=True,
+        )
+        self.define_keybind(
+            "l",
+            Localization.get("en", "ffk-check-last-move"),
+            ["check_last_move"],
+            state=KeybindState.ACTIVE,
+            include_spectators=True,
+        )
+
+    def supports_score_actions(self) -> bool:
+        return False
+
+    def _is_info_enabled(self, player: Player) -> str | None:
+        if self.status != "playing":
+            return "action-not-playing"
+        return None
+
+    def _is_touch_info_hidden(self, player: Player) -> Visibility:
+        user = self.get_user(player)
+        if self.status == "playing" and self.is_touch_client(user):
+            return Visibility.VISIBLE
+        return Visibility.HIDDEN
+
+    def _board_lines(self, locale: str, viewer: Player) -> list[str]:
+        lines: list[str] = []
+        for row in range(self.grid_rows):
+            for col in range(self.grid_cols):
+                lines.append(self.get_cell_label(row, col, viewer, locale))
+        return lines
+
+    def _action_check_board(self, player: Player, action_id: str) -> None:
+        user = self.get_user(player)
+        if not user:
+            return
+        self.live_status_box(
+            player,
+            "ffk_board",
+            lambda p, live_user: self._board_lines(live_user.locale, p),
+        )
+
+    def _action_check_progress(self, player: Player, action_id: str) -> None:
+        user = self.get_user(player)
+        kp = self._as_kono_player(player)
+        if not user or not kp:
+            return
+        home = len(
+            player_piece_cells(self.state, player.id)
+            & set(TARGET_CELLS[kp.player_num])
+        )
+        user.speak_l(
+            "ffk-progress", buffer="game", home=home, total=PIECES_PER_PLAYER
+        )
+
+    def _action_check_last_move(self, player: Player, action_id: str) -> None:
+        user = self.get_user(player)
+        if not user:
+            return
+        if len(self.last_move) == 2:
+            user.speak_l(
+                "ffk-last-move",
+                buffer="game",
+                **{
+                    "from": self._coord(self.last_move[0]),
+                    "to": self._coord(self.last_move[1]),
+                },
+            )
+        else:
+            user.speak_l("ffk-last-move-none", buffer="game")

--- a/server/games/fivefieldkono/moves.py
+++ b/server/games/fivefieldkono/moves.py
@@ -1,0 +1,71 @@
+"""Move generation and application for Five Field Kono."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .state import (
+    BOARD_SIZE,
+    FORWARD_DROW,
+    TARGET_CELLS,
+    FiveFieldKonoState,
+    cell_index,
+    cell_rowcol,
+)
+
+
+@dataclass(frozen=True)
+class Move:
+    source: int
+    destination: int
+
+
+def legal_destinations(board, source: int, player_num: int) -> list[int]:
+    """Empty forward-diagonal cells reachable from `source`. No captures."""
+    piece = board[source]
+    if piece is None or piece.owner_num != player_num:
+        return []
+    row, col = cell_rowcol(source)
+    drow = FORWARD_DROW[player_num]
+    dests: list[int] = []
+    for dcol in (-1, 1):
+        nr, nc = row + drow, col + dcol
+        if 0 <= nr < BOARD_SIZE and 0 <= nc < BOARD_SIZE:
+            idx = cell_index(nr, nc)
+            if board[idx] is None:
+                dests.append(idx)
+    return dests
+
+
+def generate_legal_moves(state: FiveFieldKonoState, player_num: int) -> list[Move]:
+    moves: list[Move] = []
+    for src, piece in enumerate(state.board):
+        if piece is None or piece.owner_num != player_num:
+            continue
+        for dst in legal_destinations(state.board, src, player_num):
+            moves.append(Move(source=src, destination=dst))
+    return moves
+
+
+def apply_move(state: FiveFieldKonoState, move: Move) -> None:
+    piece = state.board[move.source]
+    state.board[move.source] = None
+    state.board[move.destination] = piece
+
+
+def has_any_legal_move(state: FiveFieldKonoState, player_num: int) -> bool:
+    for src, piece in enumerate(state.board):
+        if piece is None or piece.owner_num != player_num:
+            continue
+        if legal_destinations(state.board, src, player_num):
+            return True
+    return False
+
+
+def is_winner(state: FiveFieldKonoState, player_num: int) -> bool:
+    cells = {
+        idx
+        for idx, piece in enumerate(state.board)
+        if piece is not None and piece.owner_num == player_num
+    }
+    return cells == set(TARGET_CELLS[player_num])

--- a/server/games/fivefieldkono/state.py
+++ b/server/games/fivefieldkono/state.py
@@ -1,0 +1,66 @@
+"""Serializable state models for Five Field Kono."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from mashumaro.mixins.json import DataClassJSONMixin
+
+BOARD_SIZE = 5
+NUM_CELLS = BOARD_SIZE * BOARD_SIZE  # 25
+PIECES_PER_PLAYER = 7
+
+# Player 1 ("south") occupies rows 0-1 and moves toward higher rows.
+# Player 2 ("north") occupies rows 3-4 and moves toward lower rows.
+START_CELLS: dict[int, frozenset[int]] = {
+    1: frozenset({0, 1, 2, 3, 4, 5, 9}),
+    2: frozenset({20, 21, 22, 23, 24, 15, 19}),
+}
+# Win by occupying the opponent's start cells.
+TARGET_CELLS: dict[int, frozenset[int]] = {
+    1: START_CELLS[2],
+    2: START_CELLS[1],
+}
+# Forward row delta per player (P1 goes up in index, P2 goes down).
+FORWARD_DROW: dict[int, int] = {1: 1, 2: -1}
+
+
+def cell_index(row: int, col: int) -> int:
+    return row * BOARD_SIZE + col
+
+
+def cell_rowcol(index: int) -> tuple[int, int]:
+    return divmod(index, BOARD_SIZE)
+
+
+def opponent_num(player_num: int) -> int:
+    return 3 - player_num
+
+
+@dataclass
+class Piece(DataClassJSONMixin):
+    owner_id: str
+    owner_num: int
+
+
+@dataclass
+class FiveFieldKonoState(DataClassJSONMixin):
+    board: list[Piece | None] = field(default_factory=lambda: [None] * NUM_CELLS)
+    current_player_num: int = 1
+
+
+def build_initial_state(p1_id: str, p2_id: str) -> FiveFieldKonoState:
+    state = FiveFieldKonoState()
+    for idx in START_CELLS[1]:
+        state.board[idx] = Piece(owner_id=p1_id, owner_num=1)
+    for idx in START_CELLS[2]:
+        state.board[idx] = Piece(owner_id=p2_id, owner_num=2)
+    return state
+
+
+def player_piece_cells(state: FiveFieldKonoState, owner_id: str) -> set[int]:
+    return {
+        idx
+        for idx, piece in enumerate(state.board)
+        if piece is not None and piece.owner_id == owner_id
+    }

--- a/server/locales/en/fivefieldkono.ftl
+++ b/server/locales/en/fivefieldkono.ftl
@@ -29,3 +29,11 @@ ffk-win-you = You moved all your pieces home and won!
 ffk-win-other = { $player } moved all their pieces home and won.
 ffk-win-stuck-you = Your opponent has no legal moves. You win!
 ffk-win-stuck-other = { $player } wins: you have no legal moves left.
+
+# Info actions
+ffk-check-board = Review board
+ffk-check-progress = My progress
+ffk-check-last-move = Last move
+ffk-progress = { $home } of { $total } pieces home.
+ffk-last-move = Last move: { $from } to { $to }.
+ffk-last-move-none = No moves have been made yet.

--- a/server/locales/en/fivefieldkono.ftl
+++ b/server/locales/en/fivefieldkono.ftl
@@ -1,0 +1,13 @@
+# Five Field Kono localization
+
+game-name-fivefieldkono = Five Field Kono
+
+# Game start
+ffk-game-started = { $p1 } is player 1 (south), { $p2 } is player 2 (north). { $first } goes first.
+
+# Cell labels (grid)
+ffk-cell-empty = { $coord }, empty.
+ffk-cell-own = { $coord }, your piece.
+ffk-cell-opponent = { $coord }, { $owner }'s piece.
+ffk-cell-selected = { $label } Selected.
+ffk-cell-move-target = { $coord }, move here.

--- a/server/locales/en/fivefieldkono.ftl
+++ b/server/locales/en/fivefieldkono.ftl
@@ -11,3 +11,21 @@ ffk-cell-own = { $coord }, your piece.
 ffk-cell-opponent = { $coord }, { $owner }'s piece.
 ffk-cell-selected = { $label } Selected.
 ffk-cell-move-target = { $coord }, move here.
+
+# Selection & movement
+ffk-select-own-piece = Select one of your own pieces first.
+ffk-piece-no-moves = That piece has no legal moves.
+ffk-piece-selected = Selected { $coord }. { $count } { $count ->
+    [one] move
+   *[other] moves
+} available.
+ffk-selection-cleared = Selection cleared.
+ffk-illegal-move = That is not a legal move for the selected piece.
+ffk-move-you = You move from { $from } to { $to }.
+ffk-move-other = { $player } moves from { $from } to { $to }.
+
+# Win / loss
+ffk-win-you = You moved all your pieces home and won!
+ffk-win-other = { $player } moved all their pieces home and won.
+ffk-win-stuck-you = Your opponent has no legal moves. You win!
+ffk-win-stuck-other = { $player } wins: you have no legal moves left.

--- a/server/locales/vi/fivefieldkono.ftl
+++ b/server/locales/vi/fivefieldkono.ftl
@@ -26,3 +26,11 @@ ffk-win-you = Bạn đã đưa tất cả quân về đích và chiến thắng!
 ffk-win-other = { $player } đã đưa tất cả quân về đích và chiến thắng.
 ffk-win-stuck-you = Đối thủ không còn nước đi. Bạn thắng!
 ffk-win-stuck-other = { $player } thắng: bạn không còn nước đi hợp lệ.
+
+# Hành động thông tin
+ffk-check-board = Xem bàn cờ
+ffk-check-progress = Tiến độ của tôi
+ffk-check-last-move = Nước đi cuối
+ffk-progress = { $home } trên { $total } quân đã về đích.
+ffk-last-move = Nước đi cuối: { $from } đến { $to }.
+ffk-last-move-none = Chưa có nước đi nào.

--- a/server/locales/vi/fivefieldkono.ftl
+++ b/server/locales/vi/fivefieldkono.ftl
@@ -11,3 +11,18 @@ ffk-cell-own = { $coord }, quân của bạn.
 ffk-cell-opponent = { $coord }, quân của { $owner }.
 ffk-cell-selected = { $label } Đã chọn.
 ffk-cell-move-target = { $coord }, đi tới đây.
+
+# Chọn & di chuyển
+ffk-select-own-piece = Hãy chọn một quân của bạn trước.
+ffk-piece-no-moves = Quân đó không có nước đi hợp lệ.
+ffk-piece-selected = Đã chọn { $coord }. Có { $count } nước đi.
+ffk-selection-cleared = Đã bỏ chọn.
+ffk-illegal-move = Đó không phải nước đi hợp lệ cho quân đã chọn.
+ffk-move-you = Bạn đi từ { $from } đến { $to }.
+ffk-move-other = { $player } đi từ { $from } đến { $to }.
+
+# Thắng / thua
+ffk-win-you = Bạn đã đưa tất cả quân về đích và chiến thắng!
+ffk-win-other = { $player } đã đưa tất cả quân về đích và chiến thắng.
+ffk-win-stuck-you = Đối thủ không còn nước đi. Bạn thắng!
+ffk-win-stuck-other = { $player } thắng: bạn không còn nước đi hợp lệ.

--- a/server/locales/vi/fivefieldkono.ftl
+++ b/server/locales/vi/fivefieldkono.ftl
@@ -1,0 +1,13 @@
+# Bản địa hóa Five Field Kono
+
+game-name-fivefieldkono = Cờ Kono 5 Ô
+
+# Bắt đầu ván
+ffk-game-started = { $p1 } là người chơi 1 (nam), { $p2 } là người chơi 2 (bắc). { $first } đi trước.
+
+# Nhãn ô (lưới)
+ffk-cell-empty = { $coord }, trống.
+ffk-cell-own = { $coord }, quân của bạn.
+ffk-cell-opponent = { $coord }, quân của { $owner }.
+ffk-cell-selected = { $label } Đã chọn.
+ffk-cell-move-target = { $coord }, đi tới đây.

--- a/server/tests/test_fivefieldkono.py
+++ b/server/tests/test_fivefieldkono.py
@@ -299,3 +299,36 @@ def test_last_move_action_reports_none_then_move():
 def test_supports_score_actions_false():
     game = make_kono(start=True)
     assert game.supports_score_actions() is False
+
+
+# ----------------------------------------------------------------------------
+# Task 6: bot
+# ----------------------------------------------------------------------------
+
+
+def test_bot_returns_legal_grid_action():
+    game = make_kono(start=True)
+    p = game._get_player_by_num(game.state.current_player_num)
+    from ..games.fivefieldkono.bot import bot_think
+    action_id = bot_think(game, p)
+    assert action_id is not None and action_id.startswith("grid_cell_")
+
+
+def test_bot_plays_full_game_to_terminal():
+    import random as _r
+    _r.seed(1234)
+    game = make_kono(start=True)
+    from ..games.fivefieldkono.bot import choose_move
+    for _ in range(1000):
+        if game.status != "playing":
+            break
+        num = game.state.current_player_num
+        p = game._get_player_by_num(num)
+        moves = generate_legal_moves(game.state, num)
+        assert moves, "stuck should have ended the game"
+        mv = choose_move(game.state, num)
+        assert mv in moves
+        game.on_grid_select(p, *divmod(mv.source, 5))
+        game.on_grid_select(p, *divmod(mv.destination, 5))
+        game.flush_menus()
+    assert game.status == "finished"

--- a/server/tests/test_fivefieldkono.py
+++ b/server/tests/test_fivefieldkono.py
@@ -302,6 +302,42 @@ def test_supports_score_actions_false():
 
 
 # ----------------------------------------------------------------------------
+# Regression: moves must be reachable through the action/menu dispatch path
+# (the real client sends grid_cell_<r>_<c> action ids, not on_grid_select).
+# ----------------------------------------------------------------------------
+
+from ..game_utils.grid_mixin import grid_cell_id  # noqa: E402
+
+
+def test_turn_menu_exposes_grid_cells_and_select():
+    game = make_kono(start=True)
+    p = game._get_player_by_num(game.state.current_player_num)
+    action_ids = {r.action.id for r in game.get_all_visible_actions(p)}
+    assert any(
+        a.startswith("grid_cell_") for a in action_ids
+    ), "no board cells in turn menu"
+    assert game.find_action(p, "grid_select") is not None, "no Enter/select action"
+
+
+def test_move_through_action_dispatch():
+    game = make_kono(start=True)
+    p = game._get_player_by_num(game.state.current_player_num)
+    move = generate_legal_moves(game.state, p.player_num)[0]
+    src_id = grid_cell_id(*divmod(move.source, 5))
+    dst_id = grid_cell_id(*divmod(move.destination, 5))
+    assert game.find_action(p, src_id) is not None, "source cell action not registered"
+
+    game.execute_action(p, src_id)   # select the piece
+    game.flush_menus()
+    assert game.selected_square.get(p.id) == move.source
+
+    game.execute_action(p, dst_id)   # move to the destination
+    game.flush_menus()
+    assert game.state.board[move.destination] is not None
+    assert game.state.board[move.source] is None
+
+
+# ----------------------------------------------------------------------------
 # Task 6: bot
 # ----------------------------------------------------------------------------
 

--- a/server/tests/test_fivefieldkono.py
+++ b/server/tests/test_fivefieldkono.py
@@ -198,3 +198,74 @@ def test_cell_label_reads_coordinate():
     p1 = game._get_player_by_num(1)
     label = game.get_cell_label(0, 0, p1, "en")
     assert "A1" in label
+
+
+# ----------------------------------------------------------------------------
+# Task 4: turn interaction
+# ----------------------------------------------------------------------------
+
+
+def test_two_step_select_then_move():
+    game = make_kono(start=True)
+    p = game._get_player_by_num(game.state.current_player_num)
+    move = generate_legal_moves(game.state, p.player_num)[0]
+    sr, sc = divmod(move.source, 5)
+    dr, dc = divmod(move.destination, 5)
+
+    game.on_grid_select(p, sr, sc)          # select piece
+    assert game.selected_square.get(p.id) == move.source
+    game.on_grid_select(p, dr, dc)          # move
+    game.flush_menus()
+    assert game.state.board[move.destination] is not None
+    assert game.state.board[move.source] is None
+    assert p.id not in game.selected_square
+    assert game.state.current_player_num != p.player_num
+
+
+def test_reselecting_same_square_deselects():
+    game = make_kono(start=True)
+    p = game._get_player_by_num(game.state.current_player_num)
+    move = generate_legal_moves(game.state, p.player_num)[0]
+    sr, sc = divmod(move.source, 5)
+    game.on_grid_select(p, sr, sc)
+    game.on_grid_select(p, sr, sc)
+    assert p.id not in game.selected_square
+
+
+def test_win_by_completion_finishes_game():
+    game = make_kono(start=True)
+    p = game._get_player_by_num(1)
+    game.state.board = [None] * 25
+    targets = sorted(TARGET_CELLS[1])
+    for idx in targets[:6]:
+        game.state.board[idx] = Piece(owner_id=p.id, owner_num=1)
+    last = targets[6]                       # 24 = (4,4)
+    lr, lc = divmod(last, 5)
+    src = (lr - 1) * 5 + (lc - 1 if lc > 0 else lc + 1)   # (3,3) = 18
+    game.state.board[src] = Piece(owner_id=p.id, owner_num=1)
+    game.state.current_player_num = 1
+    game.current_player = p
+    game.on_grid_select(p, *divmod(src, 5))
+    game.on_grid_select(p, lr, lc)
+    game.flush_menus()
+    assert game.winner_num == 1
+    assert game.win_reason == "completed"
+    assert game.status == "finished"
+
+
+def test_stuck_opponent_loses():
+    game = make_kono(start=True)
+    p1 = game._get_player_by_num(1)
+    p2 = game._get_player_by_num(2)
+    game.state.board = [None] * 25
+    # P1 can move; P2 has a single piece stuck on the far edge (row 0).
+    game.state.board[cell_index(2, 2)] = Piece(owner_id=p1.id, owner_num=1)
+    game.state.board[cell_index(0, 2)] = Piece(owner_id=p2.id, owner_num=2)
+    game.state.current_player_num = 1
+    game.current_player = p1
+    game.on_grid_select(p1, 2, 2)
+    game.on_grid_select(p1, 3, 3)
+    game.flush_menus()
+    assert game.winner_num == 1
+    assert game.win_reason == "stuck"
+    assert game.status == "finished"

--- a/server/tests/test_fivefieldkono.py
+++ b/server/tests/test_fivefieldkono.py
@@ -54,3 +54,93 @@ def test_cell_index_roundtrip_and_opponent():
     assert cell_index(1, 4) == 9
     assert cell_rowcol(9) == (1, 4)
     assert opponent_num(1) == 2 and opponent_num(2) == 1
+
+
+# ----------------------------------------------------------------------------
+# Task 2: moves
+# ----------------------------------------------------------------------------
+
+from ..games.fivefieldkono.moves import (  # noqa: E402
+    Move,
+    apply_move,
+    generate_legal_moves,
+    has_any_legal_move,
+    is_winner,
+    legal_destinations,
+)
+from ..games.fivefieldkono.state import (  # noqa: E402
+    FiveFieldKonoState,
+    Piece,
+)
+
+
+def _empty_state():
+    return FiveFieldKonoState(board=[None] * 25, current_player_num=1)
+
+
+def test_forward_diagonals_only_for_p1():
+    state = _empty_state()
+    src = cell_index(2, 2)  # C3, index 12
+    state.board[src] = Piece(owner_id="p1", owner_num=1)
+    dests = set(legal_destinations(state.board, src, 1))
+    # P1 moves to row+1 diagonals only: (3,1)=16 and (3,3)=18
+    assert dests == {cell_index(3, 1), cell_index(3, 3)}
+
+
+def test_forward_diagonals_only_for_p2():
+    state = _empty_state()
+    src = cell_index(2, 2)
+    state.board[src] = Piece(owner_id="p2", owner_num=2)
+    dests = set(legal_destinations(state.board, src, 2))
+    # P2 moves to row-1 diagonals only: (1,1)=6 and (1,3)=8
+    assert dests == {cell_index(1, 1), cell_index(1, 3)}
+
+
+def test_blocked_destination_is_illegal():
+    state = _empty_state()
+    src = cell_index(2, 2)
+    state.board[src] = Piece(owner_id="p1", owner_num=1)
+    state.board[cell_index(3, 1)] = Piece(owner_id="p1", owner_num=1)  # own blocks
+    state.board[cell_index(3, 3)] = Piece(owner_id="p2", owner_num=2)  # opp blocks
+    assert legal_destinations(state.board, src, 1) == []
+
+
+def test_edge_column_has_single_diagonal():
+    state = _empty_state()
+    src = cell_index(2, 0)  # A3, col 0 -> only (3,1)
+    state.board[src] = Piece(owner_id="p1", owner_num=1)
+    assert set(legal_destinations(state.board, src, 1)) == {cell_index(3, 1)}
+
+
+def test_apply_move_moves_piece():
+    state = _empty_state()
+    src = cell_index(2, 2)
+    dst = cell_index(3, 3)
+    state.board[src] = Piece(owner_id="p1", owner_num=1)
+    apply_move(state, Move(source=src, destination=dst))
+    assert state.board[src] is None
+    assert state.board[dst].owner_id == "p1"
+
+
+def test_win_when_all_pieces_on_targets():
+    state = _empty_state()
+    for idx in TARGET_CELLS[1]:
+        state.board[idx] = Piece(owner_id="p1", owner_num=1)
+    assert is_winner(state, 1) is True
+
+
+def test_stuck_player_has_no_moves():
+    state = _empty_state()
+    # A single P1 piece at top row can never move forward (row+1 off board).
+    state.board[cell_index(4, 2)] = Piece(owner_id="p1", owner_num=1)
+    assert has_any_legal_move(state, 1) is False
+
+
+def test_generate_legal_moves_from_initial_state():
+    state = build_initial_state("p1", "p2")
+    p1_moves = generate_legal_moves(state, 1)
+    # Row-1 has empty gaps at 6,7,8, so every P1 start piece has at least one
+    # empty forward diagonal at the opening.
+    assert {m.source for m in p1_moves} == set(START_CELLS[1])
+    # Player 2 mirrors: every P2 start piece can also move at the opening.
+    assert {m.source for m in generate_legal_moves(state, 2)} == set(START_CELLS[2])

--- a/server/tests/test_fivefieldkono.py
+++ b/server/tests/test_fivefieldkono.py
@@ -269,3 +269,33 @@ def test_stuck_opponent_loses():
     assert game.winner_num == 1
     assert game.win_reason == "stuck"
     assert game.status == "finished"
+
+
+# ----------------------------------------------------------------------------
+# Task 5: info actions
+# ----------------------------------------------------------------------------
+
+
+def test_progress_action_counts_home_pieces():
+    game = make_kono(start=True)
+    p1 = game._get_player_by_num(1)
+    user = game.get_user(p1)
+    user.clear_messages()
+    game._action_check_progress(p1, "check_progress")
+    # At game start no P1 pieces sit on opponent target cells -> "0 of 7".
+    expected = Localization.get("en", "ffk-progress", home=0, total=7)
+    assert expected in user.get_spoken_messages()
+
+
+def test_last_move_action_reports_none_then_move():
+    game = make_kono(start=True)
+    p = game._get_player_by_num(game.state.current_player_num)
+    user = game.get_user(p)
+    user.clear_messages()
+    game._action_check_last_move(p, "check_last_move")
+    assert Localization.get("en", "ffk-last-move-none") in user.get_spoken_messages()
+
+
+def test_supports_score_actions_false():
+    game = make_kono(start=True)
+    assert game.supports_score_actions() is False

--- a/server/tests/test_fivefieldkono.py
+++ b/server/tests/test_fivefieldkono.py
@@ -144,3 +144,57 @@ def test_generate_legal_moves_from_initial_state():
     assert {m.source for m in p1_moves} == set(START_CELLS[1])
     # Player 2 mirrors: every P2 start piece can also move at the opening.
     assert {m.source for m in generate_legal_moves(state, 2)} == set(START_CELLS[2])
+
+
+# ----------------------------------------------------------------------------
+# Task 3: game skeleton, registration, rendering
+# ----------------------------------------------------------------------------
+
+from ..games import GameRegistry  # noqa: E402
+from ..games.fivefieldkono.game import (  # noqa: E402
+    FiveFieldKonoGame,
+    FiveFieldKonoOptions,
+)
+from ..users.test_user import MockUser  # noqa: E402
+
+
+def make_kono(*, start: bool = False, player_count: int = 2) -> FiveFieldKonoGame:
+    game = FiveFieldKonoGame(options=FiveFieldKonoOptions())
+    game.setup_keybinds()
+    for index in range(player_count):
+        name = f"Player{index + 1}"
+        game.add_player(name, MockUser(name, uuid=f"p{index + 1}"))
+    game.host = "Player1"
+    if start:
+        game.on_start()
+    return game
+
+
+def test_game_is_registered():
+    assert GameRegistry.get("fivefieldkono") is FiveFieldKonoGame
+
+
+def test_metadata():
+    assert FiveFieldKonoGame.get_type() == "fivefieldkono"
+    assert FiveFieldKonoGame.get_category() == "board"
+    assert FiveFieldKonoGame.get_min_players() == 2
+    assert FiveFieldKonoGame.get_max_players() == 2
+
+
+def test_on_start_sets_up_board_and_grid():
+    game = make_kono(start=True)
+    assert game.status == "playing"
+    assert game.grid_rows == 5 and game.grid_cols == 5
+    assert sum(1 for c in game.state.board if c is not None) == 14
+    assert game.current_player is not None
+
+
+def test_game_name_localized():
+    assert Localization.get("en", "game-name-fivefieldkono") == "Five Field Kono"
+
+
+def test_cell_label_reads_coordinate():
+    game = make_kono(start=True)
+    p1 = game._get_player_by_num(1)
+    label = game.get_cell_label(0, 0, p1, "en")
+    assert "A1" in label

--- a/server/tests/test_fivefieldkono.py
+++ b/server/tests/test_fivefieldkono.py
@@ -1,0 +1,56 @@
+"""Tests for Five Field Kono."""
+
+from pathlib import Path
+
+from ..games.fivefieldkono.state import (
+    NUM_CELLS,
+    PIECES_PER_PLAYER,
+    START_CELLS,
+    TARGET_CELLS,
+    build_initial_state,
+    cell_index,
+    cell_rowcol,
+    opponent_num,
+    player_piece_cells,
+)
+from ..messages.localization import Localization
+
+_locales_dir = Path(__file__).parent.parent / "locales"
+Localization.init(_locales_dir)
+
+
+def test_start_cells_are_correct():
+    assert START_CELLS[1] == frozenset({0, 1, 2, 3, 4, 5, 9})
+    assert START_CELLS[2] == frozenset({20, 21, 22, 23, 24, 15, 19})
+
+
+def test_targets_are_opponent_start_cells():
+    assert TARGET_CELLS[1] == START_CELLS[2]
+    assert TARGET_CELLS[2] == START_CELLS[1]
+
+
+def test_parity_matches_between_start_and_target():
+    # Diagonal moves preserve (row+col) parity; each side must have matching
+    # even/odd counts so every piece can reach a target on its own diagonal.
+    def parity_counts(cells):
+        even = sum(1 for c in cells if (c // 5 + c % 5) % 2 == 0)
+        return even, len(cells) - even
+    assert parity_counts(START_CELLS[1]) == parity_counts(TARGET_CELLS[1])
+    assert parity_counts(START_CELLS[2]) == parity_counts(TARGET_CELLS[2])
+
+
+def test_initial_state_places_seven_pieces_each():
+    state = build_initial_state("p1", "p2")
+    assert len(state.board) == NUM_CELLS
+    p1 = player_piece_cells(state, "p1")
+    p2 = player_piece_cells(state, "p2")
+    assert p1 == START_CELLS[1]
+    assert p2 == START_CELLS[2]
+    assert len(p1) == PIECES_PER_PLAYER
+    assert len(p2) == PIECES_PER_PLAYER
+
+
+def test_cell_index_roundtrip_and_opponent():
+    assert cell_index(1, 4) == 9
+    assert cell_rowcol(9) == (1, 4)
+    assert opponent_num(1) == 2 and opponent_num(2) == 1

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -275,6 +275,7 @@ class TestGameRegistryIntegration:
             "tradeoff": "dice",
             "twentyone": "cards",
             "uno": "cards",
+            "fivefieldkono": "board",
             "yahtzee": "dice",
         }
 


### PR DESCRIPTION
## Summary

Adds **Five Field Kono**, a 2-player Korean abstract strategy board game, as game #43 (category `board`). It's a diagonal race: each player moves seven stones one square diagonally forward across a 5×5 board to occupy the opponent's starting cells. There are no captures, and if a player has no legal move on their turn they lose. Includes a depth-limited negamax bot.

Because the board renders through the existing generic grid-menu infrastructure (`GridGameMixin`), this is **server-side only** — no client changes were needed; it works across desktop, web, and mobile.

## What's included

- **Game package** `server/games/fivefieldkono/` split into `state.py` (board/setup), `moves.py` (legal moves, win/stuck detection), `game.py` (`FiveFieldKonoGame`, two-step select→move interaction modeled on Chess), and `bot.py` (negamax).
- **Registration** in `server/games/__init__.py`; catalog counts bumped 42→43 (README/CLAUDE/AGENTS) and the registry category integration test updated.
- **Localization** — full EN + VI strings in `server/locales/{en,vi}/fivefieldkono.ftl`, in parity (verified with `compare_locales.py`). Vietnamese is provisional and flagged for native review.
- **Player manuals** — EN + VI at `server/documentation/content/{en,vi}/games/fivefieldkono.md`.
- **Info actions & keybinds** — board review (`b`), progress (`p`), last move (`l`), plus touch-client action ordering. No point scoring (`supports_score_actions()` is `False`).

## Gameplay

- 5×5 board, columns A–E / rows 1–5. Player 1 starts on the near row plus the two outer second-row squares (7 stones); Player 2 mirrors on the far side.
- Stones move one square diagonally, forward only, onto an empty cell. No captures.
- Win by landing all seven stones on the opponent's seven starting cells. If it's your turn and you have no legal move, you lose.

## Testing

- New `server/tests/test_fivefieldkono.py` (29 tests): setup/parity, move generation, win and stuck detection, two-step interaction, win-by-completion and stuck-loss, info actions, and the negamax bot playing a full game to a terminal state.
- Includes regression tests that drive a move through `execute_action("grid_cell_…")` — the real client dispatch path — after an earlier bug where the turn menu registered no grid cells (the game omitted `create_turn_action_set`), leaving players unable to move.
- Full server suite green: **2343 passed**.

## Notes for review

- Vietnamese strings and manual are agent-authored and provisional — they need a native pass.
- Ruleset implemented is the standard forward-only diagonal race with "no legal move = loss" (chosen to avoid unresolvable draws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
