### PR TITLE
Add Lounge: a chat-only table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -781,11 +781,29 @@ Mobile rules:
   language names; metadata complements it and does not replace it.
 
 ### Game Counts and Catalog
-The server currently registers **45 games**:
+The server currently registers **46 games**:
 - category ids are `cards`, `dice`, `board`, `poker`, `arcade`, and `misc`
 - the Play menu exposes a persisted category filter with dynamic per-category game counts
 - games usually expose one category through `get_category()`, while `get_categories()` supports future multi-category games
-- recent additions include `Metal Pipe`, `Nine`, `Senet`, `Cards Against Humanity`, `21`, `Age of Heroes`, `UNO`, `Exploding Kittens`, `BANG! The Bullet`, and `Monopoly`
+- recent additions include `Metal Pipe`, `Nine`, `Senet`, `Cards Against Humanity`, `21`, `Age of Heroes`, `UNO`, `Exploding Kittens`, `BANG! The Bullet`, `Monopoly`, and `Lounge`
+
+#### Games Without a Play Phase
+`Game.has_play_phase()` returns `True` for every game that waits in a lobby
+until the host starts it. A social room returns `False`: its `waiting` status
+is its live state, it never becomes `playing`, and it therefore keeps letting
+newcomers take a seat instead of turning them into spectators. `Lounge` is the
+current example.
+
+Framework code that reads `waiting` as "has not begun yet" must ask this hook
+rather than special-casing a game type. Current consumers are the table
+listings (`_table_status_key`, which reports `table-status-open-room`), the
+table-creation prompt (which skips `waiting-for-players`), and the cross-game
+touch-menu invariant in `server/tests/test_touch_client_support.py`.
+
+Such a game owns the rest of its lobby story: it refuses `start_game` through
+`_is_start_game_enabled` with a localized explanation, hides the dead Start
+row, refuses bots and table saves the same way, and keeps its gameplay keybinds
+in `KeybindState.IDLE`.
 
 ### Key Tech Stack
 - Python 3.11, `asyncio`, `websockets>=12.0`, `mashumaro`, `fluent-runtime`, `openskill`, `argon2-cffi`

--- a/server/core/server.py
+++ b/server/core/server.py
@@ -2510,6 +2510,24 @@ PlayAural Server
         )
         self._user_states[user.username] = {"menu": "active_tables_filter_menu"}
 
+    def _table_status_key(self, table: "Table") -> str:
+        """Return the localized status key describing a table in a listing.
+
+        Games without a play phase (social rooms such as the Lounge) are live
+        while their status is "waiting", so reporting them as waiting would
+        tell listeners the room has not begun when in fact it is open.
+        """
+        game = table.game
+        if not game:
+            return "table-status-waiting"
+        if game.status == "playing":
+            return "table-status-playing"
+        if game.status == "finished":
+            return "table-status-finished"
+        if not game.has_play_phase():
+            return "table-status-open-room"
+        return "table-status-waiting"
+
     def _get_tables_menu_items(
         self, user: NetworkUser, game_type: str, page: int = 1
     ) -> tuple[list[MenuItem], PaginatedMenuPage[Any]]:
@@ -2561,18 +2579,7 @@ PlayAural Server
                 if member.username != table.host
             ]
             members_str = Localization.format_list_and(user.locale, member_names)
-            if table.game:
-                if table.game.status == "waiting":
-                    status_key = "table-status-waiting"
-                elif table.game.status == "playing":
-                    status_key = "table-status-playing"
-                elif table.game.status == "finished":
-                    status_key = "table-status-finished"
-                else:
-                    status_key = "table-status-waiting"
-            else:
-                status_key = "table-status-waiting"
-            status_text = Localization.get(user.locale, status_key)
+            status_text = Localization.get(user.locale, self._table_status_key(table))
 
             if member_count == 1:
                 listing_key = "table-listing-game-one-status"
@@ -2688,18 +2695,7 @@ PlayAural Server
             ]
             members_str = Localization.format_list_and(user.locale, member_names)
 
-            if table.game:
-                if table.game.status == "waiting":
-                    status_key = "table-status-waiting"
-                elif table.game.status == "playing":
-                    status_key = "table-status-playing"
-                elif table.game.status == "finished":
-                    status_key = "table-status-finished"
-                else:
-                    status_key = "table-status-waiting"
-            else:
-                status_key = "table-status-waiting"
-            status_text = Localization.get(user.locale, status_key)
+            status_text = Localization.get(user.locale, self._table_status_key(table))
 
             if member_count == 1:
                 listing_key = "table-listing-game-one-status"
@@ -6469,15 +6465,19 @@ PlayAural Server
                             game=local_game_name
                         )
 
-                min_players = game_class.get_min_players()
-                max_players = game_class.get_max_players()
-                user.speak_l(
-                    "waiting-for-players",
-                    buffer="game",
-                    current=len(game.players),
-                    min=min_players,
-                    max=max_players,
-                )
+                # A room without a play phase is already open, so the
+                # "waiting for players" prompt would misdescribe it. Those
+                # games greet their host themselves when the seat is created.
+                if game_class.has_play_phase():
+                    min_players = game_class.get_min_players()
+                    max_players = game_class.get_max_players()
+                    user.speak_l(
+                        "waiting-for-players",
+                        buffer="game",
+                        current=len(game.players),
+                        min=min_players,
+                        max=max_players,
+                    )
 
         elif selection_id.startswith("table_"):
             table_id = selection_id[6:]  # Remove "table_" prefix

--- a/server/documentation/content/en/games/lounge.md
+++ b/server/documentation/content/en/games/lounge.md
@@ -1,0 +1,94 @@
+\*\*Lounge\*\*
+
+The Lounge is a table made for talking. There is no match to win and no turns to wait for: you sit down, chat with everyone else at the table, and use a few room tools that make a voice-only room easier to share.
+
+It holds 1 to 20 people. You can open one on your own and wait for company, and anyone may walk in later and take a seat, because the room never closes itself into a game in progress.
+
+\*\*Getting In\*\*
+
+Create a Lounge from the games list like any other table, or join an existing one from the tables list. When you arrive you hear a short welcome and, if the host has set one, the current room topic.
+
+The room stays open as long as somebody is in it. It closes on its own once the last person leaves, so there is nothing to save and nothing to end.
+
+\*\*Talking\*\*
+
+The Lounge uses the normal table chat. Anything you send to the table is heard by everyone seated and by anyone watching. Table voice chat works here as well, exactly as it does at any other table.
+
+Because the Lounge never starts a game, chat, emotes, and every room tool are available from the moment you sit down.
+
+\*\*Emotes\*\*
+
+Your room menu is a list of emotes. Choose one and it plays for the whole room: you hear it in the first person, and everyone else hears your name.
+
+\* \*\*Wave:\*\* Greet the room.
+\* \*\*Laugh:\*\* Burst out laughing.
+\* \*\*Applaud:\*\* Clap for someone.
+\* \*\*Boo:\*\* Disagree loudly.
+\* \*\*Raise a toast:\*\* Toast the room.
+\* \*\*Facepalm:\*\* React to something painful.
+\* \*\*Think it over:\*\* Take a thoughtful pause.
+\* \*\*Celebrate:\*\* Cheer about good news.
+
+Each emote comes with its own sound, so the room stays lively even when nobody is typing.
+
+\*\*Nudging Someone\*\*
+
+\*\*Nudge someone\*\* picks one person from a list and sends them a private sound with a short message. You hear who you nudged, they hear who nudged them, and everyone else hears that the nudge happened. It is a friendly way to get the attention of someone who may have stepped away from their keyboard.
+
+\*\*Dice And Coin\*\*
+
+Two small party tools are always at hand:
+
+\* \*\*Roll two dice:\*\* Rolls two six-sided dice and announces both numbers and the total.
+\* \*\*Flip a coin:\*\* Announces heads or tails.
+
+They settle arguments, pick who goes first in some other game, or simply give the room something to react to.
+
+\*\*Stepping Away\*\*
+
+\*\*Mark yourself away\*\* tells the room you have stepped out without giving up your seat. Everyone hears that you are away, and the room information panel marks you. Choosing the same item again brings you back and announces your return.
+
+\*\*The Room Topic\*\*
+
+The topic says what the room is about right now. Only the host can change it, and everyone hears the new topic when it is set or cleared. Anyone can hear the current topic at any time with \*\*Read the room topic\*\*, and newcomers hear it automatically when they arrive.
+
+A topic is one plain line of up to 120 characters. Sending an empty topic clears it.
+
+\*\*Room Information\*\*
+
+\*\*Room information\*\* opens a panel that stays current while you read it:
+
+\* Who hosts the room and what the topic is.
+\* How many people are seated, how many are watching, and how many are away.
+\* How many emotes the room has played.
+\* The current room settings.
+\* One line per person, marking the host, anyone away, and anyone watching.
+
+\*\*Waiting And Watching\*\*
+
+People who join as spectators can read the room, follow the chat, hear the topic, and open the room information panel. Emotes, nudges, dice, coin flips, and the away marker belong to the people seated, so take a seat if you want to join in.
+
+Bots cannot be added to a Lounge. It is a room for people.
+
+\*\*Room Options\*\*
+
+The host can change these while the room is open:
+
+\* \*\*Emotes:\*\* Turns the emote list on or off for everyone (default on).
+\* \*\*Nudges:\*\* Turns private nudges on or off (default on).
+\* \*\*Dice and coin:\*\* Turns the dice roll and coin flip on or off (default on).
+\* \*\*Waiting time between room actions:\*\* How long each person waits between emotes, nudges, dice rolls and coin flips, from 0 to 60 seconds (default 3). It keeps a busy room comfortable to listen to.
+
+If a tool is turned off, choosing it explains that the host has disabled it rather than failing silently.
+
+\*\*Keyboard Shortcuts\*\*
+
+\* \*\*T:\*\* Read the room topic.
+\* \*\*Shift plus T:\*\* Set the room topic (host only).
+\* \*\*R:\*\* Open room information.
+\* \*\*A:\*\* Mark yourself away, or come back.
+\* \*\*N:\*\* Nudge someone.
+\* \*\*D:\*\* Roll two dice.
+\* \*\*F:\*\* Flip a coin.
+
+Emotes live in the room menu itself: move through the list and choose the one you want.

--- a/server/documentation/content/es/games/lounge.md
+++ b/server/documentation/content/es/games/lounge.md
@@ -1,0 +1,94 @@
+\*\*Sala de Charla\*\*
+
+La Sala de Charla es una mesa hecha para hablar. No hay partida que ganar ni turnos que esperar: te sientas, charlas con el resto de la mesa, y usas unas cuantas herramientas de sala que hacen más cómodo compartir un espacio solo de voz.
+
+Caben de 1 a 20 personas. Puedes abrir una tú solo y esperar compañía, y cualquiera puede entrar más tarde y sentarse, porque la sala nunca se cierra convirtiéndose en una partida en curso.
+
+\*\*Cómo entrar\*\*
+
+Crea una Sala de Charla desde la lista de juegos como cualquier otra mesa, o únete a una existente desde la lista de mesas. Al llegar escuchas una bienvenida corta y, si el anfitrión ha puesto uno, el tema actual de la sala.
+
+La sala sigue abierta mientras haya alguien dentro. Se cierra sola cuando se va la última persona, así que no hay nada que guardar ni nada que terminar.
+
+\*\*Hablar\*\*
+
+La Sala de Charla usa el chat de mesa normal. Todo lo que envías a la mesa lo escuchan quienes están sentados y quienes están mirando. El chat de voz de mesa también funciona aquí, igual que en cualquier otra mesa.
+
+Como la Sala de Charla nunca inicia una partida, el chat, los gestos y todas las herramientas de sala están disponibles desde el momento en que te sientas.
+
+\*\*Gestos\*\*
+
+Tu menú de sala es una lista de gestos. Elige uno y suena para toda la sala: tú lo escuchas en primera persona, y los demás escuchan tu nombre.
+
+\* \*\*Saludar:\*\* Saluda a la sala.
+\* \*\*Reír:\*\* Échate a reír.
+\* \*\*Aplaudir:\*\* Aplaude a alguien.
+\* \*\*Abuchear:\*\* Muestra desacuerdo en voz alta.
+\* \*\*Brindar:\*\* Brinda por la sala.
+\* \*\*Llevarse la mano a la cara:\*\* Reacciona a algo doloroso.
+\* \*\*Pensárselo:\*\* Tómate una pausa para pensar.
+\* \*\*Celebrar:\*\* Festeja una buena noticia.
+
+Cada gesto trae su propio sonido, así que la sala sigue viva aunque nadie esté escribiendo.
+
+\*\*Dar un toque a alguien\*\*
+
+\*\*Dar un toque a alguien\*\* elige a una persona de una lista y le envía un sonido privado con un mensaje corto. Tú escuchas a quién le has dado el toque, esa persona escucha quién se lo ha dado, y los demás escuchan que el toque ha ocurrido. Es una forma amable de llamar la atención de alguien que quizá se ha apartado del teclado.
+
+\*\*Dados y moneda\*\*
+
+Siempre tienes a mano dos herramientas de fiesta:
+
+\* \*\*Tirar dos dados:\*\* Tira dos dados de seis caras y anuncia los dos números y el total.
+\* \*\*Lanzar una moneda:\*\* Anuncia cara o cruz.
+
+Sirven para zanjar discusiones, decidir quién empieza en otro juego, o simplemente dar a la sala algo a lo que reaccionar.
+
+\*\*Apartarse un momento\*\*
+
+\*\*Marcarte como ausente\*\* avisa a la sala de que te has apartado sin dejar tu sitio. Todos escuchan que estás ausente, y el panel de información de la sala te marca. Elegir la misma opción otra vez te devuelve y anuncia tu regreso.
+
+\*\*El tema de la sala\*\*
+
+El tema dice de qué trata la sala ahora mismo. Solo el anfitrión puede cambiarlo, y todos escuchan el tema nuevo cuando se pone o se borra. Cualquiera puede escuchar el tema actual en cualquier momento con \*\*Leer el tema de la sala\*\*, y quien llega nuevo lo escucha automáticamente al entrar.
+
+El tema es una sola línea de texto de hasta 120 caracteres. Enviar un tema vacío lo borra.
+
+\*\*Información de la sala\*\*
+
+\*\*Información de la sala\*\* abre un panel que se mantiene actualizado mientras lo lees:
+
+\* Quién es el anfitrión y cuál es el tema.
+\* Cuántas personas están sentadas, cuántas miran, y cuántas están ausentes.
+\* Cuántos gestos ha lanzado la sala.
+\* Los ajustes actuales de la sala.
+\* Una línea por persona, marcando al anfitrión, a quien esté ausente, y a quien esté mirando.
+
+\*\*Sentarse o solo mirar\*\*
+
+Quien entra como espectador puede leer la sala, seguir el chat, escuchar el tema, y abrir el panel de información de la sala. Los gestos, los toques, los dados, la moneda y la marca de ausente son para quienes están sentados, así que siéntate si quieres participar.
+
+En una Sala de Charla no se pueden añadir bots. Es una sala para personas.
+
+\*\*Opciones de la sala\*\*
+
+El anfitrión puede cambiarlas mientras la sala está abierta:
+
+\* \*\*Gestos:\*\* Activa o desactiva la lista de gestos para todos (activado por defecto).
+\* \*\*Toques:\*\* Activa o desactiva los toques privados (activado por defecto).
+\* \*\*Dados y moneda:\*\* Activa o desactiva la tirada de dados y el lanzamiento de moneda (activado por defecto).
+\* \*\*Espera entre acciones de sala:\*\* Cuánto espera cada persona entre gestos, toques, tiradas de dados y lanzamientos de moneda, de 0 a 60 segundos (3 por defecto). Mantiene cómoda de escuchar una sala con mucha gente.
+
+Si una herramienta está desactivada, al elegirla se explica que el anfitrión la ha desactivado, en lugar de fallar en silencio.
+
+\*\*Atajos de teclado\*\*
+
+\* \*\*T:\*\* Leer el tema de la sala.
+\* \*\*Shift más T:\*\* Poner el tema de la sala (solo el anfitrión).
+\* \*\*R:\*\* Abrir la información de la sala.
+\* \*\*A:\*\* Marcarte como ausente, o volver.
+\* \*\*N:\*\* Dar un toque a alguien.
+\* \*\*D:\*\* Tirar dos dados.
+\* \*\*F:\*\* Lanzar una moneda.
+
+Los gestos están en el propio menú de sala: recórrelo y elige el que quieras.

--- a/server/documentation/content/vi/games/lounge.md
+++ b/server/documentation/content/vi/games/lounge.md
@@ -1,0 +1,94 @@
+\*\*Phòng Trò Chuyện\*\*
+
+Phòng Trò Chuyện là một bàn dành riêng cho việc nói chuyện. Không có ván nào để thắng và không phải chờ lượt: bạn ngồi xuống, trò chuyện với mọi người ở bàn, và dùng vài công cụ phòng giúp một căn phòng chỉ có âm thanh trở nên dễ chia sẻ hơn.
+
+Phòng chứa được từ 1 đến 20 người. Bạn có thể tự mở một phòng rồi chờ người khác đến, và ai đến sau vẫn ngồi vào chỗ được, vì phòng không bao giờ tự chuyển sang trạng thái đang chơi.
+
+\*\*Vào phòng\*\*
+
+Hãy tạo một Phòng Trò Chuyện từ danh sách trò chơi như với mọi bàn khác, hoặc tham gia một phòng có sẵn từ danh sách bàn. Khi vào, bạn nghe một lời chào ngắn và, nếu chủ bàn đã đặt, nghe luôn chủ đề hiện tại của phòng.
+
+Phòng vẫn mở chừng nào còn người ở trong. Phòng tự đóng khi người cuối cùng rời đi, nên không có gì để lưu và không có gì để kết thúc.
+
+\*\*Trò chuyện\*\*
+
+Phòng Trò Chuyện dùng trò chuyện tại bàn như bình thường. Mọi tin nhắn bạn gửi cho bàn đều đến với tất cả người đang ngồi và người đang theo dõi. Trò chuyện thoại tại bàn cũng hoạt động ở đây y như mọi bàn khác.
+
+Vì Phòng Trò Chuyện không bao giờ bắt đầu một ván, trò chuyện, biểu cảm và mọi công cụ phòng đều sẵn sàng ngay khi bạn ngồi xuống.
+
+\*\*Biểu cảm\*\*
+
+Trình đơn phòng của bạn chính là danh sách biểu cảm. Hãy chọn một biểu cảm và nó sẽ phát cho cả phòng: bạn nghe ở ngôi thứ nhất, còn mọi người nghe kèm tên bạn.
+
+\* \*\*Vẫy tay:\*\* Chào cả phòng.
+\* \*\*Cười:\*\* Bật cười lớn.
+\* \*\*Vỗ tay:\*\* Tán thưởng ai đó.
+\* \*\*La ó:\*\* Phản đối thật to.
+\* \*\*Nâng ly:\*\* Chúc mừng cả phòng.
+\* \*\*Ôm mặt:\*\* Phản ứng trước điều gì đó khó đỡ.
+\* \*\*Ngẫm nghĩ:\*\* Dừng lại suy nghĩ một chút.
+\* \*\*Ăn mừng:\*\* Hò reo vì tin vui.
+
+Mỗi biểu cảm đều có âm thanh riêng, nên phòng vẫn sinh động cả khi không ai đang gõ chữ.
+
+\*\*Huých một người\*\*
+
+\*\*Huých một người\*\* cho bạn chọn một người từ danh sách rồi gửi riêng cho họ một âm thanh kèm lời nhắn ngắn. Bạn nghe mình vừa huých ai, người đó nghe ai vừa huých mình, và những người còn lại nghe rằng có một cú huých vừa xảy ra. Đây là cách thân thiện để gọi sự chú ý của người có thể đã rời bàn phím.
+
+\*\*Xúc xắc và đồng xu\*\*
+
+Luôn có sẵn hai công cụ vui nho nhỏ:
+
+\* \*\*Gieo hai xúc xắc:\*\* Gieo hai viên xúc xắc sáu mặt rồi công bố cả hai số và tổng.
+\* \*\*Tung đồng xu:\*\* Công bố mặt ngửa hoặc mặt sấp.
+
+Chúng giúp phân xử tranh cãi, chọn ai đi trước ở một trò chơi khác, hoặc đơn giản là tạo cớ cho cả phòng cùng phản ứng.
+
+\*\*Tạm rời đi\*\*
+
+\*\*Báo bạn tạm vắng\*\* cho phòng biết bạn vừa bước ra ngoài mà vẫn giữ chỗ. Mọi người nghe rằng bạn đang tạm vắng, và bảng thông tin phòng sẽ đánh dấu bạn. Chọn lại mục đó sẽ đưa bạn quay lại và thông báo cho cả phòng.
+
+\*\*Chủ đề phòng\*\*
+
+Chủ đề cho biết phòng đang bàn về chuyện gì. Chỉ chủ bàn mới đổi được chủ đề, và cả phòng đều nghe khi chủ đề được đặt hoặc bị xóa. Bất cứ lúc nào bạn cũng có thể nghe chủ đề hiện tại bằng \*\*Đọc chủ đề phòng\*\*, còn người mới đến sẽ nghe tự động khi vào phòng.
+
+Chủ đề là một dòng chữ đơn giản, tối đa 120 ký tự. Gửi chủ đề trống sẽ xóa chủ đề hiện tại.
+
+\*\*Thông tin phòng\*\*
+
+\*\*Thông tin phòng\*\* mở một bảng luôn cập nhật trong lúc bạn đọc:
+
+\* Ai là chủ bàn và chủ đề là gì.
+\* Bao nhiêu người đang ngồi, bao nhiêu người đang theo dõi, bao nhiêu người đang tạm vắng.
+\* Phòng đã chơi bao nhiêu biểu cảm.
+\* Các thiết lập phòng hiện tại.
+\* Mỗi người một dòng, có đánh dấu chủ bàn, người tạm vắng và người đang theo dõi.
+
+\*\*Ngồi xuống hay chỉ theo dõi\*\*
+
+Người vào với vai trò theo dõi vẫn đọc được thông tin phòng, nghe được trò chuyện, nghe chủ đề và mở được bảng thông tin phòng. Biểu cảm, huých, xúc xắc, đồng xu và dấu tạm vắng dành cho người đang ngồi, nên hãy ngồi vào chỗ nếu bạn muốn tham gia.
+
+Không thể thêm máy vào Phòng Trò Chuyện. Đây là căn phòng dành cho người thật.
+
+\*\*Tùy chọn phòng\*\*
+
+Chủ bàn có thể đổi các tùy chọn sau ngay khi phòng đang mở:
+
+\* \*\*Biểu cảm:\*\* Bật hoặc tắt danh sách biểu cảm cho mọi người (mặc định bật).
+\* \*\*Huých:\*\* Bật hoặc tắt cú huých riêng (mặc định bật).
+\* \*\*Xúc xắc và đồng xu:\*\* Bật hoặc tắt gieo xúc xắc và tung đồng xu (mặc định bật).
+\* \*\*Thời gian chờ giữa các hành động phòng:\*\* Mỗi người phải chờ bao lâu giữa các lần dùng biểu cảm, huých, gieo xúc xắc và tung đồng xu, từ 0 đến 60 giây (mặc định 3). Thiết lập này giúp một căn phòng đông người vẫn dễ nghe.
+
+Nếu một công cụ bị tắt, khi chọn nó bạn sẽ được giải thích rằng chủ bàn đã tắt công cụ đó, chứ không im lặng bỏ qua.
+
+\*\*Phím tắt\*\*
+
+\* \*\*T:\*\* Đọc chủ đề phòng.
+\* \*\*Shift cộng T:\*\* Đặt chủ đề phòng (chỉ chủ bàn).
+\* \*\*R:\*\* Mở thông tin phòng.
+\* \*\*A:\*\* Báo tạm vắng, hoặc quay lại.
+\* \*\*N:\*\* Huých một người.
+\* \*\*D:\*\* Gieo hai xúc xắc.
+\* \*\*F:\*\* Tung đồng xu.
+
+Biểu cảm nằm ngay trong trình đơn phòng: hãy di chuyển qua danh sách và chọn biểu cảm bạn muốn.

--- a/server/games/__init__.py
+++ b/server/games/__init__.py
@@ -49,6 +49,7 @@ from .uno.game import UnoGame
 from .explodingkittens.game import ExplodingKittensGame
 from .bang.game import BangGame
 from .monopoly.game import MonopolyGame
+from .lounge.game import LoungeGame
 
 __all__ = [
     "Game",
@@ -100,4 +101,5 @@ __all__ = [
     "ExplodingKittensGame",
     "BangGame",
     "MonopolyGame",
+    "LoungeGame",
 ]

--- a/server/games/base.py
+++ b/server/games/base.py
@@ -259,6 +259,19 @@ class Game(
         return (normalize_category(cls.get_category()),)
 
     @classmethod
+    def has_play_phase(cls) -> bool:
+        """Return whether this game has a gameplay phase after the lobby.
+
+        Almost every game does: it waits in a lobby, the host starts it, and
+        ``status`` becomes "playing". A social room such as the Lounge does
+        not — its waiting state is its live state — so framework code that
+        reads "waiting" as "has not begun yet" (table listings, lobby
+        prompts, touch-menu expectations) asks here instead of special-casing
+        individual game types.
+        """
+        return True
+
+    @classmethod
     def get_min_players(cls) -> int:
         """Return minimum number of players."""
         return 2

--- a/server/games/lounge/__init__.py
+++ b/server/games/lounge/__init__.py
@@ -1,0 +1,5 @@
+"""Lounge chat room."""
+
+from .game import LoungeGame
+
+__all__ = ["LoungeGame"]

--- a/server/games/lounge/game.py
+++ b/server/games/lounge/game.py
@@ -1,0 +1,901 @@
+"""Lounge chat room implementation.
+
+The Lounge is a table whose whole point is talking. It has no play phase: it
+stays in its open room state from the moment it is created until the last
+person leaves, so anyone can walk in as a seated participant at any time,
+table chat keeps working, and the room tools (emotes, nudges, topic, away,
+dice and coin) are available immediately.
+"""
+
+from dataclasses import dataclass, field
+import math
+import random
+import re
+
+from ..base import Game, GameOptions, Player
+from ..registry import register_game
+from ...game_utils.actions import Action, ActionSet, EditboxInput, MenuInput, Visibility
+from ...game_utils.options import BoolOption, IntOption, option_field
+from ...messages.localization import Localization
+from ...ui.keybinds import KeybindState
+from ...users.base import MenuItem, User
+
+
+TICKS_PER_SECOND = 20
+MAX_TOPIC_LENGTH = 120
+_CONTROL_CHARACTERS = re.compile(r"[\x00-\x1f\x7f]")
+
+# Emote id -> sound asset. Every asset below already ships in the shared sound
+# pack, so the Lounge needs no pack bump and no mandatory client update.
+EMOTE_SOUNDS = {
+    "wave": "join.ogg",
+    "laugh": "game_citadels/thief_laugh1.ogg",
+    "applaud": "game_uno/winround.ogg",
+    "boo": "game_uno/buzzerplay.ogg",
+    "toast": "game_bang/drink_beer.ogg",
+    "facepalm": "lsmack.ogg",
+    "think": "game_pirates/instinct1.ogg",
+    "celebrate": "gamewin.ogg",
+}
+EMOTE_ORDER = (
+    "wave",
+    "laugh",
+    "applaud",
+    "boo",
+    "toast",
+    "facepalm",
+    "think",
+    "celebrate",
+)
+
+DICE_SOUND = "game_dice/dieThrow1.ogg"
+COIN_SOUND = "game_citadels/coins_small.ogg"
+NUDGE_SOUND = "mention.ogg"
+
+ROOM_ACTION_LABELS = {
+    "nudge": "lounge-nudge",
+    "roll_dice": "lounge-roll-dice",
+    "flip_coin": "lounge-flip-coin",
+    "change_topic": "lounge-set-topic",
+    "read_topic": "lounge-read-topic",
+    "room_info": "lounge-room-info",
+}
+ROOM_ACTION_DESCRIPTIONS = {
+    "nudge": "lounge-nudge-description",
+    "roll_dice": "lounge-roll-dice-description",
+    "flip_coin": "lounge-flip-coin-description",
+    "toggle_away": "lounge-away-description",
+    "change_topic": "lounge-set-topic-description",
+    "read_topic": "lounge-read-topic-description",
+    "room_info": "lounge-room-info-description",
+}
+
+
+@dataclass
+class LoungePlayer(Player):
+    """Per-person Lounge state."""
+
+    away: bool = False
+    cooldown_ticks: int = 0
+
+
+@dataclass
+class LoungeOptions(GameOptions):
+    """Host-configurable Lounge settings."""
+
+    allow_emotes: bool = option_field(
+        BoolOption(
+            default=True,
+            value_key="enabled",
+            label="lounge-set-allow-emotes",
+            change_msg="lounge-option-changed-allow-emotes",
+            description="lounge-desc-allow-emotes",
+        )
+    )
+    allow_nudges: bool = option_field(
+        BoolOption(
+            default=True,
+            value_key="enabled",
+            label="lounge-set-allow-nudges",
+            change_msg="lounge-option-changed-allow-nudges",
+            description="lounge-desc-allow-nudges",
+        )
+    )
+    allow_party_tools: bool = option_field(
+        BoolOption(
+            default=True,
+            value_key="enabled",
+            label="lounge-set-allow-party-tools",
+            change_msg="lounge-option-changed-allow-party-tools",
+            description="lounge-desc-allow-party-tools",
+        )
+    )
+    action_cooldown: int = option_field(
+        IntOption(
+            default=3,
+            min_val=0,
+            max_val=60,
+            value_key="seconds",
+            label="lounge-set-action-cooldown",
+            change_msg="lounge-option-changed-action-cooldown",
+            prompt="lounge-prompt-action-cooldown",
+            description="lounge-desc-action-cooldown",
+        )
+    )
+
+
+@dataclass
+@register_game
+class LoungeGame(Game):
+    """A table dedicated to talking rather than playing."""
+
+    players: list[LoungePlayer] = field(default_factory=list)
+    options: LoungeOptions = field(default_factory=LoungeOptions)
+
+    topic: str = ""
+    topic_author: str = ""
+    emote_count: int = 0
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "Lounge"
+
+    @classmethod
+    def get_type(cls) -> str:
+        return "lounge"
+
+    @classmethod
+    def get_category(cls) -> str:
+        return "misc"
+
+    @classmethod
+    def has_play_phase(cls) -> bool:
+        """The room is live while it waits; it never starts anything."""
+        return False
+
+    @classmethod
+    def get_min_players(cls) -> int:
+        return 1
+
+    @classmethod
+    def get_max_players(cls) -> int:
+        return 20
+
+    @classmethod
+    def get_supported_leaderboards(cls) -> list[str]:
+        return []
+
+    def create_player(
+        self, player_id: str, name: str, is_bot: bool = False
+    ) -> LoungePlayer:
+        return LoungePlayer(id=player_id, name=name, is_bot=is_bot)
+
+    # ======================================================================
+    # Room lifecycle
+    # ======================================================================
+
+    def on_start(self) -> None:
+        """The Lounge has no play phase, so starting keeps the room open.
+
+        Nothing normally reaches this hook: ``_is_start_game_enabled`` and
+        ``prestart_validate`` both refuse a start. It stays defensive so a
+        direct call cannot leave the table in a gameplay status that would
+        turn later arrivals into spectators.
+        """
+        self.status = "waiting"
+        self.game_active = False
+        self._sync_table_status()
+        self.refresh_menus()
+
+    def prestart_validate(self) -> list[str]:
+        return ["lounge-cannot-start"]
+
+    def on_tick(self) -> None:
+        """Count down each person's room-action cooldown."""
+        super().on_tick()
+        for player in self.players:
+            if player.cooldown_ticks > 0:
+                player.cooldown_ticks -= 1
+
+    def add_player(self, name: str, user: User) -> LoungePlayer:
+        player = super().add_player(name, user)
+        self._greet(player)
+        return player
+
+    def add_spectator(self, name: str, user: User) -> LoungePlayer:
+        player = super().add_spectator(name, user)
+        self._greet(player)
+        return player
+
+    def _greet(self, player: Player) -> None:
+        """Tell one arrival what this table is and what it is talking about."""
+        user = self.get_user(player)
+        if not user or player.is_bot:
+            return
+        key = "lounge-welcome-spectator" if player.is_spectator else "lounge-welcome"
+        user.speak_l(key, buffer="game")
+        if self.topic:
+            user.speak_l(
+                "lounge-topic-current",
+                buffer="game",
+                player=self.topic_author,
+                topic=self.topic,
+            )
+
+    # ======================================================================
+    # Framework affordances the Lounge deliberately turns off
+    # ======================================================================
+
+    def _is_start_game_enabled(self, player: Player) -> str | None:
+        """There is no game to start, so explain that instead of starting one."""
+        return "lounge-cannot-start"
+
+    def _is_start_game_hidden(self, player: Player) -> Visibility:
+        """Keep the dead Start row out of the room menu.
+
+        This is not readiness gating: the Lounge has no play phase at all, so a
+        permanently disabled Start row would only add noise to the menu that is
+        the room's main interface. Attempts through the Enter keybind still
+        reach ``_is_start_game_enabled`` and hear the explanation.
+        """
+        return Visibility.HIDDEN
+
+    def _is_add_bot_enabled(self, player: Player) -> str | None:
+        return "lounge-no-bots"
+
+    def _is_save_table_enabled(self, player: Player) -> str | None:
+        return "lounge-no-save"
+
+    def supports_score_actions(self) -> bool:
+        """The Lounge keeps no scores."""
+        return False
+
+    # ======================================================================
+    # Shared helpers
+    # ======================================================================
+
+    def _player_locale(self, player: Player) -> str:
+        user = self.get_user(player)
+        return user.locale if user else "en"
+
+    def _seated_players(self) -> list[LoungePlayer]:
+        return [player for player in self.players if not player.is_spectator]
+
+    def _spectators(self) -> list[LoungePlayer]:
+        return [player for player in self.players if player.is_spectator]
+
+    def _cooldown_ticks(self) -> int:
+        return max(0, int(self.options.action_cooldown)) * TICKS_PER_SECOND
+
+    def _start_cooldown(self, player: Player) -> None:
+        player.cooldown_ticks = self._cooldown_ticks()
+
+    def _cooldown_reason(self, player: Player) -> tuple[str, dict] | None:
+        """Return the remaining wait, in whole seconds, when one is running."""
+        remaining = getattr(player, "cooldown_ticks", 0)
+        if remaining <= 0:
+            return None
+        seconds = max(1, math.ceil(remaining / TICKS_PER_SECOND))
+        return ("lounge-cooldown-wait", {"seconds": seconds})
+
+    def _room_action_blocked(self, player: Player) -> str | tuple[str, dict] | None:
+        """Shared guard for every seated-only room action."""
+        if player.is_spectator:
+            return "lounge-spectator-blocked"
+        return self._cooldown_reason(player)
+
+    def _is_room_action_hidden(self, player: Player) -> Visibility:
+        """Room tools stay in the menu even while a cooldown is running.
+
+        The room menu is a persistent list. Dropping rows while a cooldown
+        ticks would destroy every client's focus anchor, so the rows remain
+        visible and simply resolve as disabled.
+        """
+        return Visibility.HIDDEN if player.is_spectator else Visibility.VISIBLE
+
+    def _is_emote_enabled(self, player: Player) -> str | tuple[str, dict] | None:
+        if not self.options.allow_emotes:
+            return "lounge-emotes-disabled"
+        return self._room_action_blocked(player)
+
+    def _is_nudge_enabled(self, player: Player) -> str | tuple[str, dict] | None:
+        if not self.options.allow_nudges:
+            return "lounge-nudges-disabled"
+        return self._room_action_blocked(player)
+
+    def _is_party_tool_enabled(self, player: Player) -> str | tuple[str, dict] | None:
+        if not self.options.allow_party_tools:
+            return "lounge-party-tools-disabled"
+        return self._room_action_blocked(player)
+
+    def _is_toggle_away_enabled(self, player: Player) -> str | None:
+        if player.is_spectator:
+            return "lounge-spectator-blocked"
+        return None
+
+    def _is_change_topic_enabled(self, player: Player) -> str | tuple[str, dict] | None:
+        if player.is_spectator:
+            return "lounge-spectator-blocked"
+        if player.name != self.host:
+            return ("lounge-topic-not-host", {"host": self.host})
+        return None
+
+    def _is_read_topic_enabled(self, player: Player) -> str | None:
+        return None
+
+    def _is_room_info_enabled(self, player: Player) -> str | None:
+        return None
+
+    def _is_touch_only_hidden(self, player: Player) -> Visibility:
+        """Standard info rows are turn-menu buttons on touch clients only."""
+        user = self.get_user(player)
+        if self.is_touch_client(user):
+            return Visibility.VISIBLE
+        return Visibility.HIDDEN
+
+    def _is_whos_at_table_hidden(self, player: Player) -> Visibility:
+        user = self.get_user(player)
+        if self.is_touch_client(user):
+            return Visibility.VISIBLE
+        return super()._is_whos_at_table_hidden(player)
+
+    def _get_room_action_label(self, player: Player, action_id: str) -> str:
+        locale = self._player_locale(player)
+        if action_id.startswith("emote_"):
+            emote_id = action_id.removeprefix("emote_")
+            return Localization.get(locale, f"lounge-emote-{emote_id}")
+        if action_id == "toggle_away":
+            key = (
+                "lounge-mark-back"
+                if getattr(player, "away", False)
+                else "lounge-mark-away"
+            )
+            return Localization.get(locale, key)
+        return Localization.get(locale, ROOM_ACTION_LABELS[action_id])
+
+    def _get_room_action_description(self, player: Player, action_id: str) -> str | None:
+        locale = self._player_locale(player)
+        if action_id.startswith("emote_"):
+            return Localization.get(locale, "lounge-emote-description")
+        description_key = ROOM_ACTION_DESCRIPTIONS.get(action_id)
+        if not description_key:
+            return None
+        return Localization.get(locale, description_key)
+
+    # ======================================================================
+    # Actions and menus
+    # ======================================================================
+
+    def create_turn_action_set(self, player: Player) -> ActionSet:
+        locale = self._player_locale(player)
+        action_set = ActionSet(name="turn")
+
+        for emote_id in EMOTE_ORDER:
+            action_set.add(
+                Action(
+                    id=f"emote_{emote_id}",
+                    label=Localization.get(locale, f"lounge-emote-{emote_id}"),
+                    handler="_action_emote",
+                    is_enabled="_is_emote_enabled",
+                    is_hidden="_is_room_action_hidden",
+                    get_label="_get_room_action_label",
+                    get_description="_get_room_action_description",
+                )
+            )
+
+        action_set.add(
+            Action(
+                id="nudge",
+                label=Localization.get(locale, "lounge-nudge"),
+                handler="_action_nudge",
+                is_enabled="_is_nudge_enabled",
+                is_hidden="_is_room_action_hidden",
+                get_label="_get_room_action_label",
+                get_description="_get_room_action_description",
+                input_request=MenuInput(
+                    prompt="lounge-nudge-prompt",
+                    options="_nudge_options",
+                    option_label="_nudge_option_label",
+                    pre_input_check="_nudge_pre_input_check",
+                ),
+            )
+        )
+        action_set.add(
+            Action(
+                id="roll_dice",
+                label=Localization.get(locale, "lounge-roll-dice"),
+                handler="_action_roll_dice",
+                is_enabled="_is_party_tool_enabled",
+                is_hidden="_is_room_action_hidden",
+                get_label="_get_room_action_label",
+                get_description="_get_room_action_description",
+            )
+        )
+        action_set.add(
+            Action(
+                id="flip_coin",
+                label=Localization.get(locale, "lounge-flip-coin"),
+                handler="_action_flip_coin",
+                is_enabled="_is_party_tool_enabled",
+                is_hidden="_is_room_action_hidden",
+                get_label="_get_room_action_label",
+                get_description="_get_room_action_description",
+            )
+        )
+        action_set.add(
+            Action(
+                id="toggle_away",
+                label=Localization.get(locale, "lounge-mark-away"),
+                handler="_action_toggle_away",
+                is_enabled="_is_toggle_away_enabled",
+                is_hidden="_is_room_action_hidden",
+                get_label="_get_room_action_label",
+                get_description="_get_room_action_description",
+            )
+        )
+        action_set.add(
+            Action(
+                id="change_topic",
+                label=Localization.get(locale, "lounge-set-topic"),
+                handler="_action_change_topic",
+                is_enabled="_is_change_topic_enabled",
+                is_hidden="_is_room_action_hidden",
+                get_label="_get_room_action_label",
+                get_description="_get_room_action_description",
+                input_request=EditboxInput(
+                    prompt="lounge-set-topic-prompt",
+                    default="",
+                ),
+            )
+        )
+        return action_set
+
+    def create_standard_action_set(self, player: Player) -> ActionSet:
+        action_set = super().create_standard_action_set(player)
+        locale = self._player_locale(player)
+
+        action_set.add(
+            Action(
+                id="read_topic",
+                label=Localization.get(locale, "lounge-read-topic"),
+                handler="_action_read_topic",
+                is_enabled="_is_read_topic_enabled",
+                is_hidden="_is_touch_only_hidden",
+                get_label="_get_room_action_label",
+                get_description="_get_room_action_description",
+                include_spectators=True,
+            )
+        )
+        action_set.add(
+            Action(
+                id="room_info",
+                label=Localization.get(locale, "lounge-room-info"),
+                handler="_action_room_info",
+                is_enabled="_is_room_info_enabled",
+                is_hidden="_is_touch_only_hidden",
+                get_label="_get_room_action_label",
+                get_description="_get_room_action_description",
+                include_spectators=True,
+            )
+        )
+
+        user = self.get_user(player)
+        if self.is_touch_client(user):
+            self._order_touch_standard_actions(
+                action_set,
+                ["read_topic", "room_info", "whos_at_table"],
+            )
+        return action_set
+
+    def setup_keybinds(self) -> None:
+        super().setup_keybinds()
+
+        # The Lounge never leaves its open room state, so every room key is an
+        # IDLE binding. "t", "s" and similar single letters are ACTIVE-only in
+        # the base game class, so reusing "t" here cannot overlap with it.
+        self.define_keybind(
+            "t",
+            "Read room topic",
+            ["read_topic"],
+            state=KeybindState.IDLE,
+            include_spectators=True,
+        )
+        self.define_keybind(
+            "shift+t",
+            "Set room topic",
+            ["change_topic"],
+            state=KeybindState.IDLE,
+        )
+        self.define_keybind(
+            "r",
+            "Room information",
+            ["room_info"],
+            state=KeybindState.IDLE,
+            include_spectators=True,
+        )
+        self.define_keybind(
+            "a",
+            "Away or back",
+            ["toggle_away"],
+            state=KeybindState.IDLE,
+        )
+        self.define_keybind(
+            "n",
+            "Nudge someone",
+            ["nudge"],
+            state=KeybindState.IDLE,
+        )
+        self.define_keybind(
+            "d",
+            "Roll two dice",
+            ["roll_dice"],
+            state=KeybindState.IDLE,
+        )
+        self.define_keybind(
+            "f",
+            "Flip a coin",
+            ["flip_coin"],
+            state=KeybindState.IDLE,
+        )
+
+    # ======================================================================
+    # Emotes
+    # ======================================================================
+
+    def _action_emote(self, player: Player, action_id: str) -> None:
+        emote_id = action_id.removeprefix("emote_")
+        sound = EMOTE_SOUNDS.get(emote_id)
+        if not sound:
+            return
+
+        self.emote_count += 1
+        self._start_cooldown(player)
+        self.broadcast_sound(sound)
+        self.broadcast_personal_l(
+            player,
+            f"lounge-emote-{emote_id}-you",
+            f"lounge-emote-{emote_id}-other",
+            buffer="game",
+        )
+        # Public room event: the emote counter and any open room information
+        # box change for everyone present.
+        self.refresh_menus()
+
+    # ======================================================================
+    # Nudges
+    # ======================================================================
+
+    def _nudge_candidates(self, player: Player) -> list[LoungePlayer]:
+        return [
+            other
+            for other in self.players
+            if other.id != player.id and not other.is_bot
+        ]
+
+    def _nudge_options(self, player: Player) -> list[str]:
+        return [other.id for other in self._nudge_candidates(player)]
+
+    def _nudge_option_label(self, player: Player, target_id: str) -> str:
+        target = self.get_player_by_id(target_id)
+        return target.name if target else target_id
+
+    def _nudge_pre_input_check(self, player: Player, action_id: str) -> str | None:
+        if not self._nudge_candidates(player):
+            return "lounge-nudge-no-targets"
+        return None
+
+    def _action_nudge(self, player: Player, target_id: str, action_id: str) -> None:
+        user = self.get_user(player)
+        if target_id == player.id:
+            if user:
+                user.speak_l("lounge-nudge-self", buffer="game")
+            return
+
+        target = self.get_player_by_id(target_id)
+        if not target:
+            if user:
+                user.speak_l(
+                    "lounge-nudge-target-left",
+                    buffer="game",
+                    target=self._nudge_option_label(player, target_id),
+                )
+            return
+
+        self._start_cooldown(player)
+        target_user = self.get_user(target)
+        if target_user:
+            self.broadcast_sound(NUDGE_SOUND, audience=[target])
+            target_user.speak_l(
+                "lounge-nudge-target",
+                buffer="game",
+                player=player.name,
+            )
+        if user:
+            user.speak_l("lounge-nudge-you", buffer="game", target=target.name)
+
+        for listener in self.players:
+            if listener.id in {player.id, target.id}:
+                continue
+            listener_user = self.get_user(listener)
+            if not listener_user:
+                continue
+            listener_user.speak_l(
+                "lounge-nudge-other",
+                buffer="game",
+                player=player.name,
+                target=target.name,
+            )
+
+    # ======================================================================
+    # Dice and coin
+    # ======================================================================
+
+    def _action_roll_dice(self, player: Player, action_id: str) -> None:
+        first = random.randint(1, 6)  # nosec B311
+        second = random.randint(1, 6)  # nosec B311
+        self._start_cooldown(player)
+        self.broadcast_sound(DICE_SOUND)
+        self.broadcast_personal_l(
+            player,
+            "lounge-roll-you",
+            "lounge-roll-other",
+            buffer="game",
+            first=first,
+            second=second,
+            total=first + second,
+        )
+
+    def _action_flip_coin(self, player: Player, action_id: str) -> None:
+        heads = random.choice([True, False])  # nosec B311
+        side_key = "lounge-coin-heads" if heads else "lounge-coin-tails"
+        self._start_cooldown(player)
+        self.broadcast_sound(COIN_SOUND)
+        self.broadcast_personal_l(
+            player,
+            "lounge-flip-you",
+            "lounge-flip-other",
+            buffer="game",
+            side=lambda locale: Localization.get(locale, side_key),
+        )
+
+    # ======================================================================
+    # Away
+    # ======================================================================
+
+    def _action_toggle_away(self, player: Player, action_id: str) -> None:
+        player.away = not getattr(player, "away", False)
+        if player.away:
+            self.broadcast_personal_l(
+                player,
+                "lounge-away-you",
+                "lounge-away-other",
+                buffer="game",
+            )
+        else:
+            self.broadcast_personal_l(
+                player,
+                "lounge-back-you",
+                "lounge-back-other",
+                buffer="game",
+            )
+        # Public room state: the actor's own row label flips, and everyone
+        # else's room information listing changes.
+        self.refresh_menus()
+
+    # ======================================================================
+    # Topic
+    # ======================================================================
+
+    def _sanitize_topic(self, raw: str) -> str:
+        """Collapse a submitted topic into one plain, speakable line."""
+        cleaned = _CONTROL_CHARACTERS.sub(" ", str(raw or ""))
+        return " ".join(cleaned.split())
+
+    def _action_change_topic(
+        self, player: Player, input_value: str, action_id: str
+    ) -> None:
+        user = self.get_user(player)
+        if player.name != self.host:
+            if user:
+                user.speak_l("lounge-topic-not-host", buffer="game", host=self.host)
+            return
+
+        submitted = str(input_value or "")
+        topic = self._sanitize_topic(submitted)
+
+        if not topic:
+            if submitted.strip():
+                if user:
+                    user.speak_l("lounge-topic-unreadable", buffer="game")
+                return
+            if not self.topic:
+                if user:
+                    user.speak_l("lounge-topic-already-empty", buffer="game")
+                return
+            self.topic = ""
+            self.topic_author = ""
+            self.broadcast_personal_l(
+                player,
+                "lounge-topic-cleared-you",
+                "lounge-topic-cleared-other",
+                buffer="game",
+            )
+            self.refresh_menus()
+            return
+
+        if len(topic) > MAX_TOPIC_LENGTH:
+            if user:
+                user.speak_l(
+                    "lounge-topic-too-long",
+                    buffer="game",
+                    max=MAX_TOPIC_LENGTH,
+                    count=len(topic),
+                )
+            return
+
+        if topic == self.topic:
+            if user:
+                user.speak_l("lounge-topic-unchanged", buffer="game")
+            return
+
+        self.topic = topic
+        self.topic_author = player.name
+        self.broadcast_personal_l(
+            player,
+            "lounge-topic-set-you",
+            "lounge-topic-set-other",
+            buffer="game",
+            topic=topic,
+        )
+        self.refresh_menus()
+
+    def _action_read_topic(self, player: Player, action_id: str) -> None:
+        user = self.get_user(player)
+        if not user:
+            return
+        if not self.topic:
+            user.speak_l("lounge-topic-none", buffer="game")
+            return
+        user.speak_l(
+            "lounge-topic-current",
+            buffer="game",
+            player=self.topic_author,
+            topic=self.topic,
+        )
+
+    # ======================================================================
+    # Room information
+    # ======================================================================
+
+    def _room_info_items(self, viewer: Player, user: User) -> list[MenuItem]:
+        locale = user.locale
+        items: list[MenuItem] = [
+            MenuItem(
+                text=Localization.get(locale, "lounge-info-host", host=self.host),
+                id="host",
+            )
+        ]
+
+        if self.topic:
+            items.append(
+                MenuItem(
+                    text=Localization.get(
+                        locale, "lounge-info-topic", topic=self.topic
+                    ),
+                    id="topic",
+                )
+            )
+            if self.topic_author:
+                items.append(
+                    MenuItem(
+                        text=Localization.get(
+                            locale,
+                            "lounge-info-topic-author",
+                            player=self.topic_author,
+                        ),
+                        id="topic_author",
+                    )
+                )
+        else:
+            items.append(
+                MenuItem(
+                    text=Localization.get(locale, "lounge-info-topic-none"),
+                    id="topic",
+                )
+            )
+
+        seated = self._seated_players()
+        spectators = self._spectators()
+        away_count = sum(1 for person in seated if person.away)
+
+        items.append(
+            MenuItem(
+                text=Localization.get(
+                    locale, "lounge-info-people", count=len(seated)
+                ),
+                id="people",
+            )
+        )
+        if spectators:
+            items.append(
+                MenuItem(
+                    text=Localization.get(
+                        locale, "lounge-info-spectators", count=len(spectators)
+                    ),
+                    id="spectators",
+                )
+            )
+        if away_count:
+            items.append(
+                MenuItem(
+                    text=Localization.get(
+                        locale, "lounge-info-away", count=away_count
+                    ),
+                    id="away",
+                )
+            )
+        items.append(
+            MenuItem(
+                text=Localization.get(
+                    locale, "lounge-info-emotes", count=self.emote_count
+                ),
+                id="emotes",
+            )
+        )
+        items.append(
+            MenuItem(
+                text=Localization.get(
+                    locale,
+                    "lounge-info-settings",
+                    emotes=self._on_off(locale, self.options.allow_emotes),
+                    nudges=self._on_off(locale, self.options.allow_nudges),
+                    party=self._on_off(locale, self.options.allow_party_tools),
+                    cooldown=self.options.action_cooldown,
+                ),
+                id="settings",
+            )
+        )
+
+        for person in seated:
+            is_host = person.name == self.host
+            if is_host and person.away:
+                key = "lounge-info-person-host-away"
+            elif is_host:
+                key = "lounge-info-person-host"
+            elif person.away:
+                key = "lounge-info-person-away"
+            else:
+                key = "lounge-info-person"
+            items.append(
+                MenuItem(
+                    text=Localization.get(locale, key, player=person.name),
+                    id=f"player:{person.id}",
+                )
+            )
+
+        for person in spectators:
+            items.append(
+                MenuItem(
+                    text=Localization.get(
+                        locale, "lounge-info-person-spectator", player=person.name
+                    ),
+                    id=f"player:{person.id}",
+                )
+            )
+
+        return items
+
+    @staticmethod
+    def _on_off(locale: str, value: bool) -> str:
+        return Localization.get(locale, "option-on" if value else "option-off")
+
+    def _action_room_info(self, player: Player, action_id: str) -> None:
+        user = self.get_user(player)
+        if not user:
+            return
+        self.live_status_box(
+            player,
+            "lounge_room_info",
+            lambda viewer, viewer_user: self._room_info_items(viewer, viewer_user),
+            focus_id="host",
+        )

--- a/server/locales/en/lounge.ftl
+++ b/server/locales/en/lounge.ftl
@@ -1,0 +1,144 @@
+# Lounge chat room messages
+
+game-name-lounge = Lounge
+
+# Room lifecycle
+lounge-welcome = Welcome to the Lounge. This table is only for talking: use table chat, play emotes, and open the room tools from your menu.
+lounge-welcome-spectator = Welcome to the Lounge. You are watching, so you can read the room and follow the chat, but emotes and room tools stay with the people seated.
+lounge-cannot-start = The Lounge is always open, so there is no game to start. Chat, emotes and room tools are available to everyone the moment they sit down.
+lounge-no-bots = The Lounge is a room for people, so bots cannot be added here. Invite someone from the players list instead.
+lounge-no-save = A Lounge is a live room, so there is nothing to save. The room closes on its own when the last person leaves.
+
+# Emote labels
+lounge-emote-wave = Wave
+lounge-emote-laugh = Laugh
+lounge-emote-applaud = Applaud
+lounge-emote-boo = Boo
+lounge-emote-toast = Raise a toast
+lounge-emote-facepalm = Facepalm
+lounge-emote-think = Think it over
+lounge-emote-celebrate = Celebrate
+lounge-emote-description = Play this emote, with its sound, for everyone in the room.
+
+# Emote announcements
+lounge-emote-wave-you = You wave at the room.
+lounge-emote-wave-other = { $player } waves at the room.
+lounge-emote-laugh-you = You burst out laughing.
+lounge-emote-laugh-other = { $player } bursts out laughing.
+lounge-emote-applaud-you = You applaud.
+lounge-emote-applaud-other = { $player } applauds.
+lounge-emote-boo-you = You boo.
+lounge-emote-boo-other = { $player } boos.
+lounge-emote-toast-you = You raise a toast to the room.
+lounge-emote-toast-other = { $player } raises a toast to the room.
+lounge-emote-facepalm-you = You facepalm.
+lounge-emote-facepalm-other = { $player } facepalms.
+lounge-emote-think-you = You think it over in silence.
+lounge-emote-think-other = { $player } thinks it over in silence.
+lounge-emote-celebrate-you = You celebrate.
+lounge-emote-celebrate-other = { $player } celebrates.
+
+# Nudge
+lounge-nudge = Nudge someone
+lounge-nudge-description = Send a private sound and a short message to one person in the room.
+lounge-nudge-prompt = Choose who to nudge
+lounge-nudge-you = You nudge { $target }.
+lounge-nudge-target = { $player } nudges you.
+lounge-nudge-other = { $player } nudges { $target }.
+lounge-nudge-no-targets = There is nobody else in the room to nudge yet. Wait for someone to sit down.
+lounge-nudge-target-left = { $target } is no longer in the room, so the nudge was not sent.
+lounge-nudge-self = You cannot nudge yourself. Pick another person in the room.
+
+# Party tools
+lounge-roll-dice = Roll two dice
+lounge-roll-dice-description = Roll two six-sided dice out loud for the whole room.
+lounge-roll-you = You roll { $first } and { $second }, for a total of { $total }.
+lounge-roll-other = { $player } rolls { $first } and { $second }, for a total of { $total }.
+lounge-flip-coin = Flip a coin
+lounge-flip-coin-description = Flip a coin out loud for the whole room.
+lounge-flip-you = You flip a coin and it lands on { $side }.
+lounge-flip-other = { $player } flips a coin and it lands on { $side }.
+lounge-coin-heads = heads
+lounge-coin-tails = tails
+
+# Away
+lounge-mark-away = Mark yourself away
+lounge-mark-back = Come back from away
+lounge-away-description = Tell the room you have stepped away. You stay seated and can come back at any time.
+lounge-away-you = You are now marked as away. You keep your seat, and everyone can see you stepped out.
+lounge-away-other = { $player } is now away.
+lounge-back-you = You are back from away.
+lounge-back-other = { $player } is back.
+
+# Topic
+lounge-set-topic = Set the room topic
+lounge-set-topic-description = Only the host can change what this room is about. Everyone hears the new topic.
+lounge-set-topic-prompt = Type the new room topic, or send it empty to clear the current one
+lounge-read-topic = Read the room topic
+lounge-read-topic-description = Hear what this room is about right now.
+lounge-topic-set-you = You set the room topic to: { $topic }
+lounge-topic-set-other = { $player } set the room topic to: { $topic }
+lounge-topic-cleared-you = You cleared the room topic.
+lounge-topic-cleared-other = { $player } cleared the room topic.
+lounge-topic-unchanged = The room topic already says exactly that, so nothing changed.
+lounge-topic-already-empty = The room has no topic to clear.
+lounge-topic-current = Room topic, set by { $player }: { $topic }
+lounge-topic-none = This room has no topic yet. The host can set one from the room tools.
+lounge-topic-not-host = Only the host can set the room topic. Ask { $host } to change it.
+lounge-topic-too-long = That topic is too long. Keep it to { $max } characters or fewer; yours had { $count }.
+lounge-topic-unreadable = That topic had no readable text in it, so the room topic was left as it was.
+
+# Room information
+lounge-room-info = Room information
+lounge-room-info-description = Read the topic, who is here, who is away, and the current room settings.
+lounge-info-host = Host: { $host }.
+lounge-info-topic = Topic: { $topic }
+lounge-info-topic-none = Topic: not set yet.
+lounge-info-topic-author = Topic set by { $player }.
+lounge-info-people = Seated: { $count } { $count ->
+        [one] person
+       *[other] people
+    }.
+lounge-info-spectators = Watching: { $count }.
+lounge-info-away = Away right now: { $count }.
+lounge-info-emotes = Emotes played in this room: { $count }.
+lounge-info-person = { $player }
+lounge-info-person-host = { $player } (host)
+lounge-info-person-away = { $player } (away)
+lounge-info-person-host-away = { $player } (host, away)
+lounge-info-person-spectator = { $player } (watching)
+lounge-info-settings = Room settings: emotes { $emotes }, nudges { $nudges }, dice and coin { $party }, waiting time between room actions { $cooldown } { $cooldown ->
+        [one] second
+       *[other] seconds
+    }.
+
+# Blocked actions
+lounge-emotes-disabled = Emotes are turned off in this room. The host can turn them back on in the room settings.
+lounge-nudges-disabled = Nudges are turned off in this room. The host can turn them back on in the room settings.
+lounge-party-tools-disabled = Dice and coin flips are turned off in this room. The host can turn them back on in the room settings.
+lounge-cooldown-wait = Wait { $seconds } more { $seconds ->
+        [one] second
+       *[other] seconds
+    } before your next emote, nudge, dice roll or coin flip.
+lounge-spectator-blocked = Only people seated in the room can do that. Take a seat first if you want to join in.
+
+# Options
+lounge-set-allow-emotes = Emotes: { $enabled }
+lounge-option-changed-allow-emotes = Emotes set to { $enabled }.
+lounge-desc-allow-emotes = When enabled, everyone seated can play emotes with their sounds for the whole room (default on).
+lounge-set-allow-nudges = Nudges: { $enabled }
+lounge-option-changed-allow-nudges = Nudges set to { $enabled }.
+lounge-desc-allow-nudges = When enabled, everyone seated can send one person a private nudge sound (default on).
+lounge-set-allow-party-tools = Dice and coin: { $enabled }
+lounge-option-changed-allow-party-tools = Dice and coin set to { $enabled }.
+lounge-desc-allow-party-tools = When enabled, everyone seated can roll two dice or flip a coin for the room (default on).
+lounge-set-action-cooldown = Waiting time between room actions: { $seconds } { $seconds ->
+        [one] second
+       *[other] seconds
+    }
+lounge-prompt-action-cooldown = Enter how many seconds each person must wait between emotes, nudges, dice rolls and coin flips
+lounge-option-changed-action-cooldown = Waiting time between room actions set to { $seconds } { $seconds ->
+        [one] second
+       *[other] seconds
+    }.
+lounge-desc-action-cooldown = How long each person waits between emotes, nudges, dice rolls and coin flips, so the room stays comfortable to listen to (default 3 seconds, range 0-60).

--- a/server/locales/en/main.ftl
+++ b/server/locales/en/main.ftl
@@ -96,6 +96,7 @@ table-listing-game-with-status = { $game } [{ $status }]: { $host }'s table ({ $
 table-status-waiting = Waiting
 table-status-playing = Playing
 table-status-finished = Finished
+table-status-open-room = Open room
 table-not-exists = Table no longer exists.
 table-full = Table is full.
 player-replaced-by-bot = { $bot } is now playing on behalf of { $player }.

--- a/server/locales/es/lounge.ftl
+++ b/server/locales/es/lounge.ftl
@@ -1,0 +1,144 @@
+# Lounge chat room messages
+
+game-name-lounge = Sala de Charla
+
+# Room lifecycle
+lounge-welcome = Bienvenido a la Sala de Charla. Esta mesa es solo para hablar: usa el chat de mesa, lanza gestos y abre las herramientas de sala desde tu menú.
+lounge-welcome-spectator = Bienvenido a la Sala de Charla. Estás como espectador, así que puedes leer la sala y seguir el chat, pero los gestos y las herramientas de sala son para quienes están sentados.
+lounge-cannot-start = La Sala de Charla siempre está abierta, así que no hay ninguna partida que iniciar. El chat, los gestos y las herramientas de sala están disponibles para todos desde el momento en que se sientan.
+lounge-no-bots = La Sala de Charla es una sala para personas, así que aquí no se pueden añadir bots. Invita a alguien desde la lista de jugadores.
+lounge-no-save = Una Sala de Charla es una sala viva, así que no hay nada que guardar. La sala se cierra sola cuando se va la última persona.
+
+# Emote labels
+lounge-emote-wave = Saludar
+lounge-emote-laugh = Reír
+lounge-emote-applaud = Aplaudir
+lounge-emote-boo = Abuchear
+lounge-emote-toast = Brindar
+lounge-emote-facepalm = Llevarse la mano a la cara
+lounge-emote-think = Pensárselo
+lounge-emote-celebrate = Celebrar
+lounge-emote-description = Lanza este gesto, con su sonido, para toda la sala.
+
+# Emote announcements
+lounge-emote-wave-you = Saludas a la sala.
+lounge-emote-wave-other = { $player } saluda a la sala.
+lounge-emote-laugh-you = Te echas a reír.
+lounge-emote-laugh-other = { $player } se echa a reír.
+lounge-emote-applaud-you = Aplaudes.
+lounge-emote-applaud-other = { $player } aplaude.
+lounge-emote-boo-you = Abucheas.
+lounge-emote-boo-other = { $player } abuchea.
+lounge-emote-toast-you = Brindas por la sala.
+lounge-emote-toast-other = { $player } brinda por la sala.
+lounge-emote-facepalm-you = Te llevas la mano a la cara.
+lounge-emote-facepalm-other = { $player } se lleva la mano a la cara.
+lounge-emote-think-you = Te lo piensas en silencio.
+lounge-emote-think-other = { $player } se lo piensa en silencio.
+lounge-emote-celebrate-you = Celebras.
+lounge-emote-celebrate-other = { $player } celebra.
+
+# Nudge
+lounge-nudge = Dar un toque a alguien
+lounge-nudge-description = Envía un sonido privado y un mensaje corto a una persona de la sala.
+lounge-nudge-prompt = Elige a quién dar un toque
+lounge-nudge-you = Das un toque a { $target }.
+lounge-nudge-target = { $player } te da un toque.
+lounge-nudge-other = { $player } da un toque a { $target }.
+lounge-nudge-no-targets = Todavía no hay nadie más en la sala a quien dar un toque. Espera a que alguien se siente.
+lounge-nudge-target-left = { $target } ya no está en la sala, así que el toque no se envió.
+lounge-nudge-self = No puedes darte un toque a ti mismo. Elige a otra persona de la sala.
+
+# Party tools
+lounge-roll-dice = Tirar dos dados
+lounge-roll-dice-description = Tira dos dados de seis caras en voz alta para toda la sala.
+lounge-roll-you = Sacas { $first } y { $second }, con un total de { $total }.
+lounge-roll-other = { $player } saca { $first } y { $second }, con un total de { $total }.
+lounge-flip-coin = Lanzar una moneda
+lounge-flip-coin-description = Lanza una moneda en voz alta para toda la sala.
+lounge-flip-you = Lanzas una moneda y cae en { $side }.
+lounge-flip-other = { $player } lanza una moneda y cae en { $side }.
+lounge-coin-heads = cara
+lounge-coin-tails = cruz
+
+# Away
+lounge-mark-away = Marcarte como ausente
+lounge-mark-back = Volver de la ausencia
+lounge-away-description = Avisa a la sala de que te has apartado un momento. Conservas tu sitio y puedes volver cuando quieras.
+lounge-away-you = Ahora estás marcado como ausente. Conservas tu sitio y todos ven que te has apartado.
+lounge-away-other = { $player } está ausente.
+lounge-back-you = Has vuelto de la ausencia.
+lounge-back-other = { $player } ha vuelto.
+
+# Topic
+lounge-set-topic = Poner el tema de la sala
+lounge-set-topic-description = Solo el anfitrión puede cambiar de qué trata la sala. Todos escuchan el tema nuevo.
+lounge-set-topic-prompt = Escribe el tema nuevo de la sala, o envíalo vacío para borrar el actual
+lounge-read-topic = Leer el tema de la sala
+lounge-read-topic-description = Escucha de qué trata la sala ahora mismo.
+lounge-topic-set-you = Pones el tema de la sala en: { $topic }
+lounge-topic-set-other = { $player } pone el tema de la sala en: { $topic }
+lounge-topic-cleared-you = Has borrado el tema de la sala.
+lounge-topic-cleared-other = { $player } ha borrado el tema de la sala.
+lounge-topic-unchanged = El tema de la sala ya dice exactamente eso, así que no ha cambiado nada.
+lounge-topic-already-empty = La sala no tiene ningún tema que borrar.
+lounge-topic-current = Tema de la sala, puesto por { $player }: { $topic }
+lounge-topic-none = Esta sala todavía no tiene tema. El anfitrión puede poner uno desde las herramientas de sala.
+lounge-topic-not-host = Solo el anfitrión puede poner el tema de la sala. Pídele a { $host } que lo cambie.
+lounge-topic-too-long = Ese tema es demasiado largo. No pases de { $max } caracteres; el tuyo tenía { $count }.
+lounge-topic-unreadable = Ese tema no tenía ningún texto legible, así que el tema de la sala se quedó como estaba.
+
+# Room information
+lounge-room-info = Información de la sala
+lounge-room-info-description = Lee el tema, quién está aquí, quién está ausente y los ajustes actuales de la sala.
+lounge-info-host = Anfitrión: { $host }.
+lounge-info-topic = Tema: { $topic }
+lounge-info-topic-none = Tema: todavía sin poner.
+lounge-info-topic-author = Tema puesto por { $player }.
+lounge-info-people = Sentados: { $count } { $count ->
+        [one] persona
+       *[other] personas
+    }.
+lounge-info-spectators = Como espectadores: { $count }.
+lounge-info-away = Ausentes ahora mismo: { $count }.
+lounge-info-emotes = Gestos lanzados en esta sala: { $count }.
+lounge-info-person = { $player }
+lounge-info-person-host = { $player } (anfitrión)
+lounge-info-person-away = { $player } (ausente)
+lounge-info-person-host-away = { $player } (anfitrión, ausente)
+lounge-info-person-spectator = { $player } (mirando)
+lounge-info-settings = Ajustes de la sala: gestos { $emotes }, toques { $nudges }, dados y moneda { $party }, espera entre acciones de sala { $cooldown } { $cooldown ->
+        [one] segundo
+       *[other] segundos
+    }.
+
+# Blocked actions
+lounge-emotes-disabled = Los gestos están desactivados en esta sala. El anfitrión puede volver a activarlos en los ajustes de la sala.
+lounge-nudges-disabled = Los toques están desactivados en esta sala. El anfitrión puede volver a activarlos en los ajustes de la sala.
+lounge-party-tools-disabled = Los dados y la moneda están desactivados en esta sala. El anfitrión puede volver a activarlos en los ajustes de la sala.
+lounge-cooldown-wait = Espera { $seconds } { $seconds ->
+        [one] segundo
+       *[other] segundos
+    } más antes de tu próximo gesto, toque, tirada de dados o lanzamiento de moneda.
+lounge-spectator-blocked = Eso solo pueden hacerlo quienes están sentados en la sala. Siéntate si quieres participar.
+
+# Options
+lounge-set-allow-emotes = Gestos: { $enabled }
+lounge-option-changed-allow-emotes = Gestos establecido en { $enabled }.
+lounge-desc-allow-emotes = Cuando está activado, todos los sentados pueden lanzar gestos con su sonido para toda la sala (activado por defecto).
+lounge-set-allow-nudges = Toques: { $enabled }
+lounge-option-changed-allow-nudges = Toques establecido en { $enabled }.
+lounge-desc-allow-nudges = Cuando está activado, todos los sentados pueden enviar a una persona un toque privado con sonido (activado por defecto).
+lounge-set-allow-party-tools = Dados y moneda: { $enabled }
+lounge-option-changed-allow-party-tools = Dados y moneda establecido en { $enabled }.
+lounge-desc-allow-party-tools = Cuando está activado, todos los sentados pueden tirar dos dados o lanzar una moneda para la sala (activado por defecto).
+lounge-set-action-cooldown = Espera entre acciones de sala: { $seconds } { $seconds ->
+        [one] segundo
+       *[other] segundos
+    }
+lounge-prompt-action-cooldown = Indica cuántos segundos debe esperar cada persona entre gestos, toques, tiradas de dados y lanzamientos de moneda
+lounge-option-changed-action-cooldown = Espera entre acciones de sala establecida en { $seconds } { $seconds ->
+        [one] segundo
+       *[other] segundos
+    }.
+lounge-desc-action-cooldown = Cuánto espera cada persona entre gestos, toques, tiradas de dados y lanzamientos de moneda, para que la sala siga siendo cómoda de escuchar (3 segundos por defecto, rango 0-60).

--- a/server/locales/es/main.ftl
+++ b/server/locales/es/main.ftl
@@ -96,6 +96,7 @@ table-listing-game-with-status = { $game } [{ $status }]: mesa de { $host } ({ $
 table-status-waiting = Esperando
 table-status-playing = Jugando
 table-status-finished = Terminada
+table-status-open-room = Sala abierta
 table-not-exists = La mesa ya no existe.
 table-full = La mesa está llena.
 player-replaced-by-bot = { $bot } ahora está jugando en nombre de { $player }.

--- a/server/locales/vi/lounge.ftl
+++ b/server/locales/vi/lounge.ftl
@@ -1,0 +1,144 @@
+# Bản địa hóa Phòng Trò Chuyện
+
+game-name-lounge = Phòng Trò Chuyện
+
+# Vòng đời của phòng
+lounge-welcome = Chào mừng đến Phòng Trò Chuyện. Bàn này chỉ để nói chuyện: hãy dùng trò chuyện tại bàn, chơi biểu cảm, và mở các công cụ phòng trong trình đơn của bạn.
+lounge-welcome-spectator = Chào mừng đến Phòng Trò Chuyện. Bạn đang theo dõi nên có thể đọc thông tin phòng và nghe trò chuyện, nhưng biểu cảm và công cụ phòng chỉ dành cho người đang ngồi trong phòng.
+lounge-cannot-start = Phòng Trò Chuyện luôn mở nên không có ván nào để bắt đầu. Trò chuyện, biểu cảm và công cụ phòng sẵn sàng cho mọi người ngay khi ngồi xuống.
+lounge-no-bots = Phòng Trò Chuyện là nơi dành cho người thật nên không thể thêm máy vào đây. Hãy mời ai đó từ danh sách người chơi.
+lounge-no-save = Phòng Trò Chuyện là một phòng đang sống nên không có gì để lưu. Phòng tự đóng khi người cuối cùng rời đi.
+
+# Nhãn biểu cảm
+lounge-emote-wave = Vẫy tay
+lounge-emote-laugh = Cười
+lounge-emote-applaud = Vỗ tay
+lounge-emote-boo = La ó
+lounge-emote-toast = Nâng ly
+lounge-emote-facepalm = Ôm mặt
+lounge-emote-think = Ngẫm nghĩ
+lounge-emote-celebrate = Ăn mừng
+lounge-emote-description = Chơi biểu cảm này, kèm âm thanh, cho cả phòng cùng nghe.
+
+# Thông báo biểu cảm
+lounge-emote-wave-you = Bạn vẫy tay chào cả phòng.
+lounge-emote-wave-other = { $player } vẫy tay chào cả phòng.
+lounge-emote-laugh-you = Bạn bật cười lớn.
+lounge-emote-laugh-other = { $player } bật cười lớn.
+lounge-emote-applaud-you = Bạn vỗ tay.
+lounge-emote-applaud-other = { $player } vỗ tay.
+lounge-emote-boo-you = Bạn la ó.
+lounge-emote-boo-other = { $player } la ó.
+lounge-emote-toast-you = Bạn nâng ly chúc cả phòng.
+lounge-emote-toast-other = { $player } nâng ly chúc cả phòng.
+lounge-emote-facepalm-you = Bạn ôm mặt.
+lounge-emote-facepalm-other = { $player } ôm mặt.
+lounge-emote-think-you = Bạn lặng lẽ ngẫm nghĩ.
+lounge-emote-think-other = { $player } lặng lẽ ngẫm nghĩ.
+lounge-emote-celebrate-you = Bạn ăn mừng.
+lounge-emote-celebrate-other = { $player } ăn mừng.
+
+# Huých nhẹ
+lounge-nudge = Huých một người
+lounge-nudge-description = Gửi riêng một âm thanh và một lời nhắn ngắn cho một người trong phòng.
+lounge-nudge-prompt = Chọn người bạn muốn huých
+lounge-nudge-you = Bạn huých { $target }.
+lounge-nudge-target = { $player } huých bạn.
+lounge-nudge-other = { $player } huých { $target }.
+lounge-nudge-no-targets = Chưa có ai khác trong phòng để huých. Hãy đợi thêm người ngồi xuống.
+lounge-nudge-target-left = { $target } không còn trong phòng nên cú huých chưa được gửi đi.
+lounge-nudge-self = Bạn không thể tự huých mình. Hãy chọn một người khác trong phòng.
+
+# Công cụ vui
+lounge-roll-dice = Gieo hai xúc xắc
+lounge-roll-dice-description = Gieo hai viên xúc xắc sáu mặt cho cả phòng cùng nghe.
+lounge-roll-you = Bạn gieo được { $first } và { $second }, tổng cộng { $total }.
+lounge-roll-other = { $player } gieo được { $first } và { $second }, tổng cộng { $total }.
+lounge-flip-coin = Tung đồng xu
+lounge-flip-coin-description = Tung một đồng xu cho cả phòng cùng nghe.
+lounge-flip-you = Bạn tung đồng xu và nó rơi vào mặt { $side }.
+lounge-flip-other = { $player } tung đồng xu và nó rơi vào mặt { $side }.
+lounge-coin-heads = ngửa
+lounge-coin-tails = sấp
+
+# Tạm vắng
+lounge-mark-away = Báo bạn tạm vắng
+lounge-mark-back = Quay lại từ trạng thái tạm vắng
+lounge-away-description = Báo cho phòng biết bạn tạm rời đi. Bạn vẫn giữ chỗ và có thể quay lại bất cứ lúc nào.
+lounge-away-you = Bạn đã được đánh dấu là tạm vắng. Bạn vẫn giữ chỗ và cả phòng biết bạn vừa bước ra ngoài.
+lounge-away-other = { $player } đang tạm vắng.
+lounge-back-you = Bạn đã quay lại từ trạng thái tạm vắng.
+lounge-back-other = { $player } đã quay lại.
+
+# Chủ đề
+lounge-set-topic = Đặt chủ đề phòng
+lounge-set-topic-description = Chỉ chủ bàn mới đổi được nội dung phòng đang bàn. Cả phòng sẽ nghe chủ đề mới.
+lounge-set-topic-prompt = Nhập chủ đề mới cho phòng, hoặc gửi trống để xóa chủ đề hiện tại
+lounge-read-topic = Đọc chủ đề phòng
+lounge-read-topic-description = Nghe xem phòng này đang bàn về chuyện gì.
+lounge-topic-set-you = Bạn đặt chủ đề phòng thành: { $topic }
+lounge-topic-set-other = { $player } đặt chủ đề phòng thành: { $topic }
+lounge-topic-cleared-you = Bạn đã xóa chủ đề phòng.
+lounge-topic-cleared-other = { $player } đã xóa chủ đề phòng.
+lounge-topic-unchanged = Chủ đề phòng đã đúng y như vậy rồi nên không có gì thay đổi.
+lounge-topic-already-empty = Phòng chưa có chủ đề nào để xóa.
+lounge-topic-current = Chủ đề phòng, do { $player } đặt: { $topic }
+lounge-topic-none = Phòng này chưa có chủ đề. Chủ bàn có thể đặt một chủ đề từ công cụ phòng.
+lounge-topic-not-host = Chỉ chủ bàn mới đặt được chủ đề phòng. Hãy nhờ { $host } đổi giúp.
+lounge-topic-too-long = Chủ đề đó quá dài. Hãy giữ trong { $max } ký tự trở xuống; chủ đề của bạn có { $count } ký tự.
+lounge-topic-unreadable = Chủ đề đó không có chữ nào đọc được nên chủ đề phòng vẫn giữ nguyên.
+
+# Thông tin phòng
+lounge-room-info = Thông tin phòng
+lounge-room-info-description = Đọc chủ đề, ai đang ở đây, ai đang tạm vắng, và các thiết lập phòng hiện tại.
+lounge-info-host = Chủ bàn: { $host }.
+lounge-info-topic = Chủ đề: { $topic }
+lounge-info-topic-none = Chủ đề: chưa đặt.
+lounge-info-topic-author = Chủ đề do { $player } đặt.
+lounge-info-people = Đang ngồi: { $count } { $count ->
+        [one] người
+       *[other] người
+    }.
+lounge-info-spectators = Đang theo dõi: { $count }.
+lounge-info-away = Đang tạm vắng: { $count }.
+lounge-info-emotes = Số biểu cảm đã chơi trong phòng: { $count }.
+lounge-info-person = { $player }
+lounge-info-person-host = { $player } (chủ bàn)
+lounge-info-person-away = { $player } (tạm vắng)
+lounge-info-person-host-away = { $player } (chủ bàn, tạm vắng)
+lounge-info-person-spectator = { $player } (đang theo dõi)
+lounge-info-settings = Thiết lập phòng: biểu cảm { $emotes }, huých { $nudges }, xúc xắc và đồng xu { $party }, thời gian chờ giữa các hành động phòng { $cooldown } { $cooldown ->
+        [one] giây
+       *[other] giây
+    }.
+
+# Hành động bị chặn
+lounge-emotes-disabled = Biểu cảm đang tắt trong phòng này. Chủ bàn có thể bật lại trong thiết lập phòng.
+lounge-nudges-disabled = Huých đang tắt trong phòng này. Chủ bàn có thể bật lại trong thiết lập phòng.
+lounge-party-tools-disabled = Gieo xúc xắc và tung đồng xu đang tắt trong phòng này. Chủ bàn có thể bật lại trong thiết lập phòng.
+lounge-cooldown-wait = Hãy đợi thêm { $seconds } { $seconds ->
+        [one] giây
+       *[other] giây
+    } nữa trước khi dùng biểu cảm, huých, gieo xúc xắc hoặc tung đồng xu lần tới.
+lounge-spectator-blocked = Chỉ người đang ngồi trong phòng mới làm được việc đó. Hãy ngồi vào chỗ nếu bạn muốn tham gia.
+
+# Tùy chọn
+lounge-set-allow-emotes = Biểu cảm: { $enabled }
+lounge-option-changed-allow-emotes = Biểu cảm đã được đặt thành { $enabled }.
+lounge-desc-allow-emotes = Khi bật, mọi người đang ngồi đều có thể chơi biểu cảm kèm âm thanh cho cả phòng (mặc định bật).
+lounge-set-allow-nudges = Huých: { $enabled }
+lounge-option-changed-allow-nudges = Huých đã được đặt thành { $enabled }.
+lounge-desc-allow-nudges = Khi bật, mọi người đang ngồi đều có thể gửi riêng một cú huých cho một người (mặc định bật).
+lounge-set-allow-party-tools = Xúc xắc và đồng xu: { $enabled }
+lounge-option-changed-allow-party-tools = Xúc xắc và đồng xu đã được đặt thành { $enabled }.
+lounge-desc-allow-party-tools = Khi bật, mọi người đang ngồi đều có thể gieo hai xúc xắc hoặc tung đồng xu cho cả phòng (mặc định bật).
+lounge-set-action-cooldown = Thời gian chờ giữa các hành động phòng: { $seconds } { $seconds ->
+        [one] giây
+       *[other] giây
+    }
+lounge-prompt-action-cooldown = Nhập số giây mỗi người phải chờ giữa các lần dùng biểu cảm, huých, gieo xúc xắc và tung đồng xu
+lounge-option-changed-action-cooldown = Thời gian chờ giữa các hành động phòng đã được đặt thành { $seconds } { $seconds ->
+        [one] giây
+       *[other] giây
+    }.
+lounge-desc-action-cooldown = Mỗi người phải chờ bao lâu giữa các lần dùng biểu cảm, huých, gieo xúc xắc và tung đồng xu, để phòng luôn dễ nghe (mặc định 3 giây, phạm vi 0-60).

--- a/server/locales/vi/main.ftl
+++ b/server/locales/vi/main.ftl
@@ -96,6 +96,7 @@ table-listing-game-with-status = { $game } [{ $status }]: Bàn của { $host } (
 table-status-waiting = Đang chờ
 table-status-playing = Đang chơi
 table-status-finished = Đã xong
+table-status-open-room = Phòng đang mở
 table-not-exists = Bàn chơi không còn tồn tại.
 table-full = Bàn đã đầy.
 player-replaced-by-bot = { $bot } đang chơi thay cho { $player }.

--- a/server/tests/test_bang.py
+++ b/server/tests/test_bang.py
@@ -258,7 +258,7 @@ def all_card_ids(game: BangGame) -> list[int]:
 
 def test_registration_metadata_options_and_catalog_count():
     assert GameRegistry.get("bang") is BangGame
-    assert len(GameRegistry.get_all()) == 45
+    assert len(GameRegistry.get_all()) == 46
     assert BangGame.get_name() == "BANG! The Bullet"
     assert BangGame.get_category() == "cards"
     assert (BangGame.get_min_players(), BangGame.get_max_players()) == (3, 8)

--- a/server/tests/test_integration.py
+++ b/server/tests/test_integration.py
@@ -257,6 +257,7 @@ class TestGameRegistryIntegration:
             "humanitycards": "cards",
             "leftrightcenter": "dice",
             "lightturret": "arcade",
+            "lounge": "misc",
             "ludo": "board",
             "metalpipe": "misc",
             "midnight": "dice",

--- a/server/tests/test_lounge.py
+++ b/server/tests/test_lounge.py
@@ -1,0 +1,613 @@
+"""Tests for the Lounge chat room."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from ..core.server import Server
+from ..games.lounge.game import (
+    EMOTE_ORDER,
+    MAX_TOPIC_LENGTH,
+    TICKS_PER_SECOND,
+    LoungeGame,
+    LoungeOptions,
+)
+from ..games.registry import GameRegistry
+from ..users.test_user import MockUser
+
+
+def make_room(
+    *,
+    player_count: int = 3,
+    spectators: int = 0,
+    touch_first: bool = False,
+    locale: str = "en",
+    **option_overrides,
+) -> tuple[LoungeGame, list[MockUser]]:
+    game = LoungeGame(options=LoungeOptions(**option_overrides))
+    game.setup_keybinds()
+    users: list[MockUser] = []
+    for index in range(player_count):
+        user = MockUser(
+            f"Player{index + 1}",
+            locale=locale,
+            uuid=f"lounge-p{index + 1}",
+        )
+        if touch_first and index == 0:
+            user.client_type = "mobile"
+        users.append(user)
+        game.add_player(user.username, user)
+    for index in range(spectators):
+        user = MockUser(
+            f"Watcher{index + 1}",
+            locale=locale,
+            uuid=f"lounge-s{index + 1}",
+        )
+        users.append(user)
+        game.add_spectator(user.username, user)
+    game.host = users[0].username
+    for user in users:
+        user.clear_messages()
+    return game, users
+
+
+def visible_action_ids(game: LoungeGame, index: int) -> list[str]:
+    return [
+        resolved.action.id
+        for resolved in game.get_all_visible_actions(game.players[index])
+    ]
+
+
+def test_room_registered_with_chat_first_metadata() -> None:
+    assert GameRegistry.get("lounge") is LoungeGame
+    game = LoungeGame()
+
+    assert game.get_name() == "Lounge"
+    assert game.get_type() == "lounge"
+    assert game.get_category() == "misc"
+    assert game.get_min_players() == 1
+    assert game.get_max_players() == 20
+    assert game.get_supported_leaderboards() == []
+    assert game.supports_score_actions() is False
+    assert game.options.allow_emotes is True
+    assert game.options.allow_nudges is True
+    assert game.options.allow_party_tools is True
+    assert game.options.action_cooldown == 3
+
+
+def test_room_stays_open_and_never_starts() -> None:
+    game, users = make_room(player_count=1)
+    host = game.players[0]
+
+    assert game.status == "waiting"
+    assert game.prestart_validate() == ["lounge-cannot-start"]
+    assert game._is_start_game_enabled(host) == "lounge-cannot-start"
+    assert "start_game" not in visible_action_ids(game, 0)
+
+    game.execute_action(host, "start_game")
+
+    assert game.status == "waiting"
+    assert users[0].get_last_spoken() == (
+        "The Lounge is always open, so there is no game to start. Chat, emotes and "
+        "room tools are available to everyone the moment they sit down."
+    )
+
+    # Even a direct start must not flip the table into a gameplay status, which
+    # would turn every later arrival into a spectator.
+    game.on_start()
+    assert game.status == "waiting"
+
+
+def test_bots_and_saving_are_refused_with_reasons() -> None:
+    game, users = make_room(player_count=1)
+    host = game.players[0]
+
+    game.execute_action(host, "add_bot")
+    assert users[0].get_last_spoken() == (
+        "The Lounge is a room for people, so bots cannot be added here. Invite "
+        "someone from the players list instead."
+    )
+    assert len(game.players) == 1
+
+    users[0].clear_messages()
+    game.execute_action(host, "save_table")
+    assert users[0].get_last_spoken() == (
+        "A Lounge is a live room, so there is nothing to save. The room closes on "
+        "its own when the last person leaves."
+    )
+
+
+def test_arrival_is_greeted_and_hears_the_current_topic() -> None:
+    game, users = make_room(player_count=1)
+    game.execute_action(game.players[0], "change_topic", "Audio games night")
+
+    latecomer = MockUser("Player2", uuid="lounge-p2")
+    game.add_player(latecomer.username, latecomer)
+
+    assert latecomer.get_spoken_messages() == [
+        "Welcome to the Lounge. This table is only for talking: use table chat, "
+        "play emotes, and open the room tools from your menu.",
+        "Room topic, set by Player1: Audio games night",
+    ]
+
+    watcher = MockUser("Watcher1", uuid="lounge-s1")
+    game.add_spectator(watcher.username, watcher)
+    assert watcher.get_spoken_messages()[0] == (
+        "Welcome to the Lounge. You are watching, so you can read the room and "
+        "follow the chat, but emotes and room tools stay with the people seated."
+    )
+
+
+def test_emote_splits_actor_and_observer_forms_and_plays_its_sound() -> None:
+    game, users = make_room(player_count=3)
+
+    game.execute_action(game.players[0], "emote_applaud")
+
+    assert users[0].get_last_spoken() == "You applaud."
+    assert users[1].get_last_spoken() == "Player1 applauds."
+    assert users[2].get_last_spoken() == "Player1 applauds."
+    assert users[1].get_sounds_played() == ["game_uno/winround.ogg"]
+    assert game.emote_count == 1
+
+
+def test_every_emote_has_a_sound_and_both_announcement_forms() -> None:
+    game, users = make_room(player_count=2, action_cooldown=0)
+
+    for emote_id in EMOTE_ORDER:
+        for user in users:
+            user.clear_messages()
+        game.execute_action(game.players[0], f"emote_{emote_id}")
+
+        actor_line = users[0].get_last_spoken()
+        observer_line = users[1].get_last_spoken()
+        assert actor_line and not actor_line.startswith("lounge-")
+        assert observer_line and not observer_line.startswith("lounge-")
+        assert actor_line != observer_line
+        assert observer_line.startswith("Player1")
+        assert len(users[1].get_sounds_played()) == 1
+
+    assert game.emote_count == len(EMOTE_ORDER)
+
+
+def test_cooldown_blocks_the_next_room_action_until_it_expires() -> None:
+    game, users = make_room(player_count=2, action_cooldown=2)
+
+    game.execute_action(game.players[0], "emote_wave")
+    users[0].clear_messages()
+
+    game.execute_action(game.players[0], "emote_laugh")
+    assert users[0].get_last_spoken() == (
+        "Wait 2 more seconds before your next emote, nudge, dice roll or coin flip."
+    )
+    assert game.emote_count == 1
+
+    # The rows stay in the menu while disabled so client focus keeps its anchor.
+    assert "emote_laugh" in visible_action_ids(game, 0)
+
+    for _ in range(2 * TICKS_PER_SECOND):
+        game.on_tick()
+
+    users[0].clear_messages()
+    game.execute_action(game.players[0], "emote_laugh")
+    assert users[0].get_last_spoken() == "You burst out laughing."
+    assert game.emote_count == 2
+
+
+def test_zero_cooldown_allows_back_to_back_room_actions() -> None:
+    game, users = make_room(player_count=2, action_cooldown=0)
+
+    game.execute_action(game.players[0], "emote_wave")
+    game.execute_action(game.players[0], "emote_boo")
+
+    assert game.emote_count == 2
+    assert users[0].get_last_spoken() == "You boo."
+
+
+def test_disabled_options_explain_which_tool_is_off() -> None:
+    game, users = make_room(
+        player_count=2,
+        allow_emotes=False,
+        allow_nudges=False,
+        allow_party_tools=False,
+    )
+
+    game.execute_action(game.players[0], "emote_wave")
+    assert users[0].get_last_spoken() == (
+        "Emotes are turned off in this room. The host can turn them back on in the "
+        "room settings."
+    )
+
+    game.execute_action(game.players[0], "nudge", game.players[1].id)
+    assert users[0].get_last_spoken() == (
+        "Nudges are turned off in this room. The host can turn them back on in the "
+        "room settings."
+    )
+
+    game.execute_action(game.players[0], "roll_dice")
+    assert users[0].get_last_spoken() == (
+        "Dice and coin flips are turned off in this room. The host can turn them "
+        "back on in the room settings."
+    )
+    assert game.emote_count == 0
+
+
+def test_nudge_is_targeted_and_reported_from_three_perspectives() -> None:
+    game, users = make_room(player_count=3)
+
+    game.execute_action(game.players[0], "nudge", game.players[1].id)
+
+    assert users[0].get_last_spoken() == "You nudge Player2."
+    assert users[1].get_last_spoken() == "Player1 nudges you."
+    assert users[2].get_last_spoken() == "Player1 nudges Player2."
+    assert users[1].get_sounds_played() == ["mention.ogg"]
+    assert users[0].get_sounds_played() == []
+    assert users[2].get_sounds_played() == []
+
+
+def test_nudge_rejects_self_and_departed_targets() -> None:
+    game, users = make_room(player_count=2)
+
+    game.execute_action(game.players[0], "nudge", game.players[0].id)
+    assert users[0].get_last_spoken() == (
+        "You cannot nudge yourself. Pick another person in the room."
+    )
+
+    users[0].clear_messages()
+    game.execute_action(game.players[0], "nudge", "lounge-ghost")
+    assert users[0].get_last_spoken() == (
+        "lounge-ghost is no longer in the room, so the nudge was not sent."
+    )
+
+
+def test_nudge_needs_someone_else_in_the_room() -> None:
+    game, users = make_room(player_count=1)
+    host = game.players[0]
+
+    assert game._nudge_options(host) == []
+    assert game._nudge_pre_input_check(host, "nudge") == "lounge-nudge-no-targets"
+
+    game.handle_event(host, {"type": "action", "action": "nudge"})
+    assert users[0].get_last_spoken() == (
+        "There is nobody else in the room to nudge yet. Wait for someone to sit down."
+    )
+
+    watcher = MockUser("Watcher1", uuid="lounge-s1")
+    game.add_spectator(watcher.username, watcher)
+    assert game._nudge_options(host) == [watcher.uuid]
+    assert game._nudge_option_label(host, watcher.uuid) == "Watcher1"
+
+
+def test_dice_and_coin_report_their_results_to_the_room() -> None:
+    game, users = make_room(player_count=2, action_cooldown=0)
+
+    with patch("server.games.lounge.game.random.randint", side_effect=[4, 5]):
+        game.execute_action(game.players[0], "roll_dice")
+
+    assert users[0].get_last_spoken() == "You roll 4 and 5, for a total of 9."
+    assert users[1].get_last_spoken() == "Player1 rolls 4 and 5, for a total of 9."
+    assert users[1].get_sounds_played() == ["game_dice/dieThrow1.ogg"]
+
+    with patch("server.games.lounge.game.random.choice", return_value=True):
+        game.execute_action(game.players[0], "flip_coin")
+
+    assert users[0].get_last_spoken() == "You flip a coin and it lands on heads."
+    assert users[1].get_last_spoken() == "Player1 flips a coin and it lands on heads."
+
+
+def test_away_toggle_announces_and_relabels_only_the_actor_row() -> None:
+    game, users = make_room(player_count=2)
+    host = game.players[0]
+
+    game.execute_action(host, "toggle_away")
+
+    assert host.away is True
+    assert users[0].get_last_spoken() == (
+        "You are now marked as away. You keep your seat, and everyone can see you "
+        "stepped out."
+    )
+    assert users[1].get_last_spoken() == "Player1 is now away."
+    assert game._get_room_action_label(host, "toggle_away") == (
+        "Come back from away"
+    )
+    assert game._get_room_action_label(game.players[1], "toggle_away") == (
+        "Mark yourself away"
+    )
+
+    game.execute_action(host, "toggle_away")
+    assert host.away is False
+    assert users[0].get_last_spoken() == "You are back from away."
+    assert users[1].get_last_spoken() == "Player1 is back."
+
+
+def test_only_the_host_sets_the_topic() -> None:
+    game, users = make_room(player_count=2)
+
+    game.execute_action(game.players[1], "change_topic", "Takeover")
+
+    assert game.topic == ""
+    assert users[1].get_last_spoken() == (
+        "Only the host can set the room topic. Ask Player1 to change it."
+    )
+
+    game.execute_action(game.players[0], "change_topic", "Weekly audio games chat")
+
+    assert game.topic == "Weekly audio games chat"
+    assert game.topic_author == "Player1"
+    assert users[0].get_last_spoken() == (
+        "You set the room topic to: Weekly audio games chat"
+    )
+    assert users[1].get_last_spoken() == (
+        "Player1 set the room topic to: Weekly audio games chat"
+    )
+
+
+def test_topic_input_is_cleaned_bounded_and_deduplicated() -> None:
+    game, users = make_room(player_count=1)
+    host = game.players[0]
+
+    game.execute_action(host, "change_topic", "  Board   games\ttonight \r\n")
+    assert game.topic == "Board games tonight"
+
+    users[0].clear_messages()
+    game.execute_action(host, "change_topic", "Board games tonight")
+    assert users[0].get_last_spoken() == (
+        "The room topic already says exactly that, so nothing changed."
+    )
+
+    users[0].clear_messages()
+    too_long = "x" * (MAX_TOPIC_LENGTH + 5)
+    game.execute_action(host, "change_topic", too_long)
+    assert game.topic == "Board games tonight"
+    assert users[0].get_last_spoken() == (
+        f"That topic is too long. Keep it to {MAX_TOPIC_LENGTH} characters or "
+        f"fewer; yours had {MAX_TOPIC_LENGTH + 5}."
+    )
+
+    users[0].clear_messages()
+    game.execute_action(host, "change_topic", "\x07\x01")
+    assert game.topic == "Board games tonight"
+    assert users[0].get_last_spoken() == (
+        "That topic had no readable text in it, so the room topic was left as it was."
+    )
+
+
+def test_topic_can_be_cleared_and_read_back() -> None:
+    game, users = make_room(player_count=2)
+    host = game.players[0]
+
+    game.execute_action(game.players[1], "read_topic")
+    assert users[1].get_last_spoken() == (
+        "This room has no topic yet. The host can set one from the room tools."
+    )
+
+    game.execute_action(host, "change_topic", "Late night talk")
+    users[1].clear_messages()
+    game.execute_action(game.players[1], "read_topic")
+    assert users[1].get_last_spoken() == (
+        "Room topic, set by Player1: Late night talk"
+    )
+
+    users[0].clear_messages()
+    users[1].clear_messages()
+    game.execute_action(host, "change_topic", "   ")
+    assert game.topic == ""
+    assert game.topic_author == ""
+    assert users[0].get_last_spoken() == "You cleared the room topic."
+    assert users[1].get_last_spoken() == "Player1 cleared the room topic."
+
+    users[0].clear_messages()
+    game.execute_action(host, "change_topic", "")
+    assert users[0].get_last_spoken() == "The room has no topic to clear."
+
+
+def test_room_information_lists_topic_people_and_settings() -> None:
+    game, users = make_room(player_count=2, spectators=1, action_cooldown=1)
+    host = game.players[0]
+
+    game.execute_action(host, "change_topic", "Coffee break")
+    game.execute_action(game.players[1], "toggle_away")
+
+    game.execute_action(host, "room_info")
+    items = users[0].menus["status_box"]["items"]
+    assert [item.id for item in items] == [
+        "host",
+        "topic",
+        "topic_author",
+        "people",
+        "spectators",
+        "away",
+        "emotes",
+        "settings",
+        "player:lounge-p1",
+        "player:lounge-p2",
+        "player:lounge-s1",
+    ]
+    assert items[0].text == "Host: Player1."
+    assert items[1].text == "Topic: Coffee break"
+    assert items[3].text == "Seated: 2 people."
+    assert items[4].text == "Watching: 1."
+    assert items[5].text == "Away right now: 1."
+    assert items[7].text == (
+        "Room settings: emotes On, nudges On, dice and coin On, waiting time "
+        "between room actions 1 second."
+    )
+    assert items[8].text == "Player1 (host)"
+    assert items[9].text == "Player2 (away)"
+    assert items[10].text == "Watcher1 (watching)"
+
+
+def test_room_information_stays_current_while_open() -> None:
+    game, users = make_room(player_count=2, action_cooldown=0)
+    host = game.players[0]
+
+    game.execute_action(host, "room_info")
+    before = users[0].menus["status_box"]["items"]
+    assert any(item.text == "Emotes played in this room: 0." for item in before)
+
+    game.execute_action(game.players[1], "emote_celebrate")
+    game.flush_menus()
+
+    after = users[0].menus["status_box"]["items"]
+    assert [item.id for item in after] == [item.id for item in before]
+    assert any(item.text == "Emotes played in this room: 1." for item in after)
+
+
+def test_spectators_read_the_room_but_cannot_use_seated_tools() -> None:
+    game, users = make_room(player_count=1, spectators=1)
+    spectator = game.players[1]
+    spectator_user = users[1]
+
+    assert spectator.is_spectator is True
+    assert visible_action_ids(game, 1) == []
+
+    game.execute_action(spectator, "emote_wave")
+    assert spectator_user.get_spoken_messages() == []
+    assert game.emote_count == 0
+
+    game.execute_action(spectator, "read_topic")
+    assert spectator_user.get_last_spoken() == (
+        "This room has no topic yet. The host can set one from the room tools."
+    )
+
+    game.execute_action(spectator, "room_info")
+    assert "status_box" in spectator_user.menus
+
+
+def test_room_menu_lists_emotes_first_then_the_other_room_tools() -> None:
+    game, users = make_room(player_count=2)
+
+    game.refresh_menus(game.players[0])
+    game.flush_menus()
+    menu_ids = [
+        item.id
+        for item in users[0].menus["turn_menu"]["items"]
+        if getattr(item, "id", None)
+    ]
+
+    expected_start = [f"emote_{emote_id}" for emote_id in EMOTE_ORDER]
+    assert menu_ids[: len(expected_start)] == expected_start
+    assert menu_ids[len(expected_start) :][:5] == [
+        "nudge",
+        "roll_dice",
+        "flip_coin",
+        "toggle_away",
+        "change_topic",
+    ]
+    assert "start_game" not in menu_ids
+    # Desktop reaches these through keybinds and the actions menu instead.
+    assert "read_topic" not in menu_ids
+    assert "room_info" not in menu_ids
+
+
+def test_touch_clients_get_the_room_info_buttons_in_order() -> None:
+    game, users = make_room(player_count=2, touch_first=True)
+
+    action_set = game.create_standard_action_set(game.players[0])
+    order = action_set._order
+    assert order.index("read_topic") < order.index("room_info")
+    assert order.index("room_info") < order.index("whos_at_table")
+
+    game.refresh_menus(game.players[0])
+    game.flush_menus()
+    menu_ids = [
+        item.id
+        for item in users[0].menus["turn_menu"]["items"]
+        if getattr(item, "id", None)
+    ]
+    assert menu_ids[-5:] == [
+        "read_topic",
+        "room_info",
+        "whos_at_table",
+        "web_actions_menu",
+        "web_leave_table",
+    ]
+    assert "check_scores" not in menu_ids
+    assert "whose_turn" not in menu_ids
+
+
+def test_room_keybinds_reach_the_room_tools() -> None:
+    game, users = make_room(player_count=2)
+    host = game.players[0]
+
+    game.handle_event(host, {"type": "keybind", "key": "r"})
+    assert "status_box" in users[0].menus
+
+    game.handle_event(host, {"type": "keybind", "key": "a"})
+    assert host.away is True
+
+    assert game._get_keybind_for_action("read_topic") == "t"
+    assert game._get_keybind_for_action("change_topic") == "shift+t"
+    assert game._get_keybind_for_action("nudge") == "n"
+    assert game._get_keybind_for_action("roll_dice") == "d"
+    assert game._get_keybind_for_action("flip_coin") == "f"
+
+
+def test_room_state_survives_a_save_and_restore_round_trip() -> None:
+    game, users = make_room(player_count=2, action_cooldown=5)
+    host = game.players[0]
+
+    game.execute_action(host, "change_topic", "Restored talk")
+    game.execute_action(game.players[1], "toggle_away")
+
+    restored = LoungeGame.from_json(game.to_json())
+    restored.rebuild_runtime_state()
+
+    assert restored.status == "waiting"
+    assert restored.topic == "Restored talk"
+    assert restored.topic_author == "Player1"
+    assert restored.emote_count == 0
+    assert restored.options.action_cooldown == 5
+    assert [player.away for player in restored.players] == [False, True]
+
+
+def test_lounge_tables_are_listed_as_an_open_room() -> None:
+    server = Server(
+        db_path=":memory:",
+        locales_dir=Path(__file__).resolve().parents[1] / "locales",
+    )
+    host = MockUser("Bob")
+    viewer = MockUser("Alice")
+    server._users = {"Bob": host, "Alice": viewer}
+    table = server._tables.create_table("lounge", "Bob", host)
+    table.game = LoungeGame()
+
+    assert server._table_status_key(table) == "table-status-open-room"
+
+    server._show_active_tables_menu(viewer)
+    texts = [
+        item.text if hasattr(item, "text") else item
+        for item in (viewer.get_current_menu_items("active_tables_menu") or [])
+    ]
+    assert any("Lounge [Open room]" in text for text in texts)
+
+
+def test_latecomers_take_a_seat_instead_of_becoming_spectators() -> None:
+    server = Server(
+        db_path=":memory:",
+        locales_dir=Path(__file__).resolve().parents[1] / "locales",
+    )
+    server._db.connect()
+    host = MockUser("Bob")
+    latecomer = MockUser("Alice")
+    server._users = {"Bob": host, "Alice": latecomer}
+    table = server._tables.create_table("lounge", "Bob", host)
+    game = LoungeGame()
+    table.game = game
+    game._table = table
+    game.initialize_lobby("Bob", host)
+
+    server._auto_join_table(latecomer, table, "lounge")
+
+    joined = game.get_player_by_id(latecomer.uuid)
+    assert joined is not None
+    assert joined.is_spectator is False
+    assert table.get_players() == table.members
+    assert game.status == "waiting"
+
+
+def test_vietnamese_room_strings_render_for_each_listener() -> None:
+    game, users = make_room(player_count=2, locale="vi")
+
+    game.execute_action(game.players[0], "emote_wave")
+
+    assert users[0].get_last_spoken() == "Bạn vẫy tay chào cả phòng."
+    assert users[1].get_last_spoken() == "Player1 vẫy tay chào cả phòng."

--- a/server/tests/test_monopoly.py
+++ b/server/tests/test_monopoly.py
@@ -138,7 +138,7 @@ def test_registration_metadata_and_catalog_count() -> None:
         "rating",
         "games_played",
     ]
-    assert len(GameRegistry.get_all()) == 45
+    assert len(GameRegistry.get_all()) == 46
     assert get_board_ids() == (
         "australia",
         "germany",

--- a/server/tests/test_touch_client_support.py
+++ b/server/tests/test_touch_client_support.py
@@ -169,6 +169,26 @@ def test_touch_waiting_lobby_hides_gameplay_actions_for_all_games(game_cls) -> N
     game, player = _new_game_with_players(game_cls, 1)
 
     assert game.status != "playing"
+
+    if not game_cls.has_play_phase():
+        # A room without a play phase (the Lounge) is already live while its
+        # status is "waiting", so its tools are meant to be reachable there.
+        # What must still hold is that a spectator only reaches the read-only
+        # subset, and never a seated-only tool such as the turn-set actions.
+        seated_ids = set(_touch_waiting_gameplay_action_ids(game, player))
+        assert seated_ids
+
+        watcher = MockUser("Watcher", uuid=f"new-game-{game.get_type()}-watcher")
+        watcher.client_type = "mobile"
+        spectator = game.add_spectator("Watcher", watcher)
+        spectator_ids = set(_touch_waiting_gameplay_action_ids(game, spectator))
+
+        assert spectator_ids < seated_ids
+        turn_set = game.get_action_set(spectator, "turn")
+        assert turn_set is not None
+        assert turn_set.get_visible_actions(game, spectator) == []
+        return
+
     assert _touch_waiting_gameplay_action_ids(game, player) == []
 
 


### PR DESCRIPTION
## Lounge: a table for talking

PlayAural has global chat and table chat, but no table whose purpose is simply
talking. This adds one as a 46th registered game.

The Lounge has **no play phase**. Its `waiting` status is its live state: it
never becomes `playing`, so people who arrive later keep taking a seat instead
of being turned into spectators, and table chat plus every room tool work from
the moment someone sits down. It holds 1 to 20 people and closes itself when
the last person leaves.

### Room tools

Reachable from the room menu, the actions menu, and dedicated keybinds:

- **Eight emotes** with sound — wave, laugh, applaud, boo, toast, facepalm,
  think, celebrate. Every announcement has a first-person form for the actor
  and a third-person form for everyone else.
- **Nudge** — picks one person and sends them a private sound plus a short
  message; actor, target and bystanders each hear their own line.
- **Room topic** — host-owned, sanitized to one plain line of up to 120
  characters, announced when set or cleared and read to every newcomer.
- **Away marker** — keeps the seat, announces the change, and flags the person
  in the room panel.
- **Dice and coin** — two six-sided dice or a coin flip, announced to the room.
- **Room information** — a live status box with the topic, who is seated, who is
  watching, who is away, the emote counter, and the current settings.

Host options: emotes, nudges, dice and coin can each be switched off, and a
per-person cooldown (0-60 s, default 3) bounds emote/nudge/dice pressure so a
busy room stays comfortable to listen to. Every blocked action explains the
specific reason instead of failing silently.

Bots cannot be added, the table cannot be saved, and there are no scores,
leaderboards or ratings. Spectators can read the room, follow the chat and open
the room panel, but the seated-only tools stay with the people seated.

### Framework change

`Game.has_play_phase()` (default `True`, `Lounge` returns `False`) lets shared
code stop reading `waiting` as "has not begun yet" instead of special-casing a
game type. Consumers:

- table listings report an open room (`table-status-open-room`) rather than
  "Waiting"; the duplicated status-key branch in the two listing paths is now a
  single `_table_status_key()` helper;
- the table-creation prompt skips the `waiting-for-players` line;
- the cross-game touch-menu invariant in `test_touch_client_support.py` asserts
  the correct rule for a room that is live while it waits — a spectator still
  reaches only the read-only subset, never a turn-set tool.

### Clients and assets

No client changes and no sound-pack bump. Every sound the Lounge plays already
ships in `client/sounds`, `web_client/sounds` and `mobile_client/sounds`; asset
presence was verified in all three.

### Localization and docs

- `en`, `vi` and `es` room strings in full key/variable/plural-arm parity,
  verified with `server/tools/compare_locales.py`.
- Player manuals for `en`, `vi` and `es`.
- `fa` has no Lounge file yet and falls back to English, matching its existing
  gaps for BANG!, Exploding Kittens and Monopoly.

The Vietnamese and Spanish strings are contributed here for convenience and
would benefit from a native reviewer's pass.

### Tests

`server/tests/test_lounge.py` adds 27 tests covering actor/observer emote forms,
every emote's sound and announcement pair, cooldown expiry, disabled-tool
reasons, three-perspective nudges, nudge self/missing-target/no-target paths,
dice and coin, the away toggle and its dynamic label, topic host-gating,
sanitizing, length bound, clearing and read-back, the live room panel and its
refresh, spectator scoping, menu ordering for desktop and touch, keybinds,
save/restore round-trip, the open-room listing, and a latecomer taking a seat.

Full suite: 3141 passed.

The Spanish translation is a separate commit so it can be split out if this
project prefers translations in their own PR.
