### PR TITLE
Spanish (es) translation: Backgammon doubling-cube overhaul, beginner guide rewrite, changelog catch-up

### DIFF
--- a/server/documentation/content/es/changelog.md
+++ b/server/documentation/content/es/changelog.md
@@ -1,5 +1,23 @@
 Registro de cambios
 
+Jueves 27 de agosto de 2026
+
+Novedades:
+
+* El portugués ya está disponible en el servidor, escritorio, web, móvil y guías de jugador, como traducción comunitaria de Tadeu Junior. El contenido que aún no se ha traducido al portugués cae de vuelta al inglés.
+
+Mejoras:
+
+* El actualizador de escritorio para Windows ahora instala las actualizaciones de PlayAural y de paquetes de sonido en una ventana accesible dedicada. Revisa el paquete descargado antes de modificar la instalación, espera a que se cierren todas las ventanas de PlayAural, verifica que el cliente actualizado inicie correctamente, y restaura la versión anterior que funcionaba si el inicio falla. Las actualizaciones fallidas o canceladas también limpian los archivos temporales y dan instrucciones de recuperación más claras.
+* Reproducir Sonidos de Escritura ahora funciona en el cuadro de chat de escritorio y en los cuadros de texto que abren los juegos, además del chat web y cuadros de texto compatibles. Las teclas normales usan una mayor variedad de sonidos, mientras que las teclas numéricas, Suprimir y Entrar tienen retroalimentación distinta. El teclado Telex vietnamita integrado de Windows y otros teclados de idioma ahora conservan un sonido para cada tecla sin duplicados al formar caracteres acentuados.
+* Backgammon ahora incluye una vista en vivo de Movimientos legales; retroalimentación más clara de Deseleccionar, fallos al sacar fichas, Deshacer, Estado, Cuenta de pips, Dados, Cubo, y puntaje; redacción personalizada para el jugador que mueve y para todos los demás; foco táctil más estable; y una guía para principiantes reconstruida. Los jugadores táctiles lanzan los dados tocando cualquier punto del tablero sin mover el foco, mientras que Siguiente destino y Destino anterior mueven el foco solo cuando se solicita.
+* El bloqueo de jugadores, los resúmenes de miembros de mesa, y el juego con el cubo de doblaje de Backgammon ya están disponibles en español.
+
+Corrección de errores:
+
+* Iniciar una mesa solo con bots y sin ningún jugador humano activo ahora se detiene antes de que la partida comience. La mesa permanece abierta y explica que un humano debe volver a un asiento de jugador, en vez de iniciar la partida y luego cancelarla.
+* Backgammon ahora puntúa correctamente los doblajes aceptados y rechazados, la posesión del cubo, las partidas Crawford, las victorias normales, los gammons, y los backgammons. También evita un doblaje inútil cuando el valor actual del cubo ya alcanza para ganar el enfrentamiento, y Deshacer restaura una ficha capturada con retroalimentación clara para todos en la mesa.
+
 Martes 25 de agosto de 2026
 
 Novedades:

--- a/server/documentation/content/es/games/backgammon.md
+++ b/server/documentation/content/es/games/backgammon.md
@@ -1,88 +1,156 @@
 \*\*Backgammon\*\*
 
-Backgammon es uno de los juegos de mesa de carrera más antiguos del mundo, con orígenes que se cree se remontan a más de cuatro mil años. Dos jugadores guían quince fichas cada uno alrededor de una pista compartida de veinticuatro puntos, tratando de llevar todas sus fichas a casa y retirarlas antes de que el oponente pueda hacer lo mismo.
+Backgammon es una carrera para exactamente dos jugadores. Cada jugador controla quince fichas en un tablero de veinticuatro puntos numerados. Tu objetivo es llevar todas tus fichas a tu cuadrante final y luego sacar las quince antes que tu oponente.
+
+PlayAural asigna a un jugador el color rojo y al otro el blanco. Los colores mantienen las mismas fichas durante todo el enfrentamiento, pero ambos jugadores escuchan los números de punto desde su propia dirección de avance.
+
+\*\*El tablero\*\*
+
+El tablero es una pista doblada en dos filas. Contiene:
+
+\* \*\*24 puntos:\*\* Los espacios donde descansan las fichas. Desde tu perspectiva, el punto 24 es el más lejano de tu cuadrante final y el punto 1 es el más cercano para sacar fichas.
+\* \*\*Tu cuadrante final:\*\* Los puntos 1 al 6. Las quince fichas deben llegar a estos seis puntos antes de que puedas empezar a sacarlas.
+\* \*\*La barra:\*\* El divisor en el medio de un tablero físico. Una ficha capturada espera aquí hasta que pueda volver a entrar.
+\* \*\*Fuera del tablero:\*\* El destino de las fichas que ya sacaste con éxito.
+
+El tablero accesible es una cuadrícula estable de dos por doce. Tu cuadrante final está abajo a la derecha. La fila inferior va del punto 12 al punto 1, y la fila superior va del punto 13 al punto 24. Tus fichas avanzan de números de punto altos hacia bajos; tu oponente avanza en la dirección contraria.
 
 \*\*Posición inicial\*\*
 
-Cada jugador empieza con quince fichas en la disposición de apertura estándar:
+Cada jugador empieza con la disposición estándar de quince fichas:
 
-\* 2 fichas en tu punto 24
-\* 5 fichas en tu punto 13
-\* 3 fichas en tu punto 8
-\* 5 fichas en tu punto 6
+\* 2 fichas en su punto 24.
+\* 5 fichas en su punto 13.
+\* 3 fichas en su punto 8.
+\* 5 fichas en su punto 6.
 
-Los colores se asignan al azar al inicio de cada enfrentamiento. Un jugador es Rojo y el otro es Blanco.
+Como los dos lados se mueven en direcciones opuestas, los números de punto de tu oponente son el reverso de los tuyos.
 
-\*\*Disposición del tablero\*\*
+\*\*Empezando una partida\*\*
 
-El tablero se muestra como una cuadrícula desde tu perspectiva, con tu área de casa en la esquina inferior derecha. Los puntos están numerados del 1 al 6 a lo largo de la parte inferior derecha, continuando del 7 al 12 a lo largo de la parte inferior izquierda, luego del 13 al 18 a lo largo de la parte superior izquierda, y del 19 al 24 a lo largo de la parte superior derecha. El movimiento sigue esta forma de herradura: tus fichas viajan desde los puntos de número alto hacia tu tablero de casa en los puntos 1 al 6. Tu oponente viaja en la dirección opuesta.
+Cada jugador lanza un dado. Los empates se vuelven a lanzar. El jugador con el número más alto toma el primer turno y usa ambos números de la tirada inicial como los dados de ese turno. Se hace una nueva tirada inicial al comienzo de cada partida dentro de un enfrentamiento.
 
-\*\*Jugabilidad\*\*
+Después del turno inicial, los jugadores alternan turnos y lanzan dos dados cada vez. En un cliente táctil, toca cualquier punto del tablero para lanzar los dados. En escritorio, presiona Entrar sobre cualquier punto del tablero o presiona R. Lanzar los dados deja tu foco en el tablero donde estaba, así puedes seguir examinando el mismo punto.
 
-Cada partida empieza con una tirada de apertura. Ambos jugadores lanzan un dado, y el que saca más alto empieza; los empates se vuelven a lanzar hasta que alguien gane. Esos dos números de apertura se usan de inmediato como el primer turno de ese jugador.
+\*\*Usando los dados\*\*
 
-Después de eso, los jugadores se turnan para lanzar dos dados y mover sus fichas según los números sacados. Cada dado es un movimiento separado. Si los dados son distintos, normalmente debes usar ambos si existen movimientos legales. Si sacas dobles, juegas ese número cuatro veces. Lanza presionando Entrar en cualquier punto del tablero.
+Cada dado normalmente mueve una ficha esa cantidad de puntos. Puedes mover dos fichas distintas, o mover una misma ficha dos veces si el punto intermedio está abierto. El orden puede importar: una ruta puede ser legal usando un dado primero y quedar bloqueada usando el otro dado primero.
 
-El menú de turno presenta los movimientos legales disponibles en ese momento. Sigues eligiendo movimientos hasta que se hayan gastado todos los dados utilizables o no quede ningún movimiento legal. Si solo se puede jugar legalmente un dado, se debe usar el dado más alto.
+Debes usar tanto de la tirada como las reglas lo permitan:
 
-\*\*Movimiento y captura\*\*
+\* Si se pueden jugar ambos dados, debes jugar los dos.
+\* Si solo se puede jugar un dado, debes jugar el dado más alto cuando el dado más alto tenga un movimiento legal.
+\* Si sacas dobles, juegas ese número cuatro veces y debes usar tantos de esos cuatro movimientos como sea posible.
+\* Si no se puede jugar ningún dado, el juego anuncia que el turno terminó.
 
-Para mover una ficha, primero selecciona el punto donde está, y luego selecciona el punto de destino. El juego relaciona automáticamente tu movimiento con el dado correcto. Puedes mover hacia:
+PlayAural evalúa la tirada completa restante, así que rechazará un movimiento que te impediría usar otro dado requerido sin necesidad. El turno termina automáticamente después de que se haya usado cada dado que se podía jugar legalmente.
+
+\*\*Seleccionando y moviendo una ficha\*\*
+
+Activa un punto que contenga una de tus fichas para seleccionarla, luego activa un destino legal. PlayAural elige el dado disponible que corresponda. Activa Deseleccionar para cancelar la selección actual. Si no hay nada seleccionado, Deseleccionar confirma que no hay ninguna ficha seleccionada.
+
+En un cliente táctil, activa Siguiente destino o Destino anterior cuando quieras que PlayAural mueva el foco entre tus opciones legales. Antes de seleccionar una ficha, estas acciones recorren los puntos de origen legales, o los puntos de entrada legales cuando tienes una ficha en la barra. Después de seleccionar una ficha, recorren sus destinos legales. Son los únicos controles de movimiento que cambian tu foco en el tablero intencionalmente.
+
+La acción Movimientos legales abre una lista en vivo de cada movimiento permitido por la tirada completa restante. Los números de punto en esa lista usan tu perspectiva. Deshacer revierte el último submovimiento del turno actual, incluida la restauración de una ficha del oponente si ese movimiento la capturó. Una vez que el turno termina, sus movimientos ya no se pueden deshacer.
+
+Puedes caer en:
 
 \* Un punto vacío.
-\* Un punto ocupado por tus propias fichas.
+\* Un punto ocupado por cualquier cantidad de tus propias fichas.
 \* Un punto ocupado por exactamente una ficha del oponente.
 
-Si caes en un punto con exactamente una ficha del oponente, esa ficha es capturada y enviada a la barra.
+Un punto con dos o más fichas del oponente está cerrado, así que no puedes caer ahí.
 
-No puedes mover hacia un punto ocupado por dos o más fichas del oponente. Esos puntos están bloqueados.
+\*\*Fichas sueltas, capturas y la barra\*\*
 
-Si tienes alguna ficha en la barra, debes volver a entrar esa ficha antes de mover cualquier otra. Cuando tienes una ficha en la barra, simplemente selecciona cualquier punto de destino y el juego mueve desde la barra automáticamente. Una ficha de la barra vuelve a entrar en un punto abierto del tablero de casa de tu oponente, usando los dados como cualquier otro movimiento. Si tienes fichas en la barra y no puedes entrar, pierdes todo tu turno.
+Una sola ficha parada sola en un punto se llama ficha suelta. Cuando una ficha del oponente cae en ese punto, la ficha suelta es capturada y se mueve a la barra.
 
-\*\*Retirar fichas\*\*
+Si tienes una o más fichas en la barra, debes hacerlas entrar todas antes de mover cualquier ficha que ya esté en el tablero. Para entrar, activa un destino abierto en el cuadrante final de tu oponente. El dado determina el punto de entrada: un 1 entra en el punto 1 del oponente desde su perspectiva, un 6 en su punto 6, y así sucesivamente. PlayAural anuncia estos destinos usando tus propios números de punto.
 
-Una vez que las quince fichas están en tu tablero de casa, puedes empezar a retirarlas. Para retirar una ficha, selecciona la ficha y luego vuelve a seleccionar el mismo punto, o presiona Entrar dos veces en él. Una tirada exacta retira una ficha directamente. Si sacas más alto que tu punto ocupado más alto, puedes retirar desde ese punto más alto. No puedes usar un dado que se pase para retirar desde un punto más bajo si todavía queda alguna ficha en un punto más alto.
+Un punto de entrada está abierto si está vacío, contiene tus propias fichas, o contiene una sola ficha suelta del oponente. Si hay varias fichas en la barra, debes hacer entrar tantas como los dados lo permitan. Después de que la última entra, cualquier dado sin usar puede mover esa misma ficha de nuevo o mover otra ficha. Si toda entrada permitida por los dados restantes está cerrada, no puedes moverte y pierdes el resto del turno.
 
-Si una ficha es capturada mientras retiras, debe ir a la barra, volver a entrar, y viajar todo el camino de vuelta a casa antes de que puedas reanudar el retiro de fichas.
+\*\*Sacando fichas\*\*
 
-\*\*Puntuación\*\*
+Solo puedes empezar a sacar fichas cuando las quince están en tu cuadrante final y ninguna está en la barra.
 
-El ganador de una partida anota puntos de enfrentamiento:
+\* Usa un dado igual al número de punto de una ficha para sacarla exactamente.
+\* Un dado mayor que el punto ocupado más alto puede sacar una ficha de ese punto ocupado más alto.
+\* No puedes usar un dado más grande de lo necesario en una ficha de un punto más bajo mientras te queden fichas en un punto más alto.
 
-\* \*\*1 punto\*\* por una victoria normal, si el perdedor ya retiró al menos una ficha.
-\* \*\*2 puntos\*\* por un gammon, si el perdedor no retiró ninguna.
-\* \*\*3 puntos\*\* por un backgammon, si el perdedor no retiró ninguna y todavía tiene una ficha en la barra o en el tablero de casa del ganador.
+Si sacar la ficha del tablero es su único destino legal, activa su punto una vez. Si la ficha podría tanto moverse dentro del tablero como salir, actívala una vez para seleccionarla y activa el mismo punto de nuevo para sacarla. Esto deja disponible el destino dentro del tablero cuando ese movimiento es estratégicamente mejor.
 
-Si se usó el cubo de doblaje, el valor final del cubo multiplica la puntuación de esa partida.
+Si una activación repetida no puede sacar la ficha, PlayAural explica por qué y cancela la selección. Si una de tus fichas restantes es capturada, debes hacerla entrar de nuevo y devolverla a tu cuadrante final antes de que puedas seguir sacando fichas.
 
-\*\*Cubo de doblaje y regla Crawford\*\*
+\*\*Ganando una partida\*\*
 
-En enfrentamientos de más de un punto, el jugador activo puede ofrecer un doblaje antes de lanzar. Si el oponente acepta, el valor del cubo se duplica y la propiedad del cubo pasa al jugador que aceptó, quien entonces es el único que puede ofrecer el próximo doblaje. Si el oponente rechaza, el jugador que ofreció gana la partida actual de inmediato por el valor actual del cubo.
+El primer jugador en sacar sus quince fichas gana la partida. El resultado básico se multiplica entonces por el cubo de doblaje, si el cubo está en uso:
 
-La regla Crawford se aplica automáticamente. Cuando un jugador está a exactamente un punto de ganar el enfrentamiento, la siguiente partida se convierte en una partida Crawford y el cubo de doblaje se desactiva para esa partida. Después de la partida Crawford, el doblaje se reanuda para todas las partidas siguientes. El cubo de doblaje no está disponible en partidas individuales (duración de enfrentamiento de 1).
+\* \*\*Victoria normal, 1 vez el cubo:\*\* El perdedor sacó al menos una ficha.
+\* \*\*Gammon, 2 veces el cubo:\*\* El perdedor no sacó ninguna ficha.
+\* \*\*Backgammon, 3 veces el cubo:\*\* El perdedor no sacó ninguna ficha y todavía tiene una ficha en la barra o en el cuadrante final del ganador.
 
-\*\*Juego por enfrentamiento\*\*
+En un enfrentamiento, el resultado se suma al puntaje del ganador. El primer jugador en alcanzar o superar el puntaje objetivo gana el enfrentamiento.
 
-Un enfrentamiento consiste en varias partidas jugadas hasta una puntuación objetivo. Después de cada partida, los puntos del ganador se suman a su puntuación de enfrentamiento. El primer jugador en alcanzar o superar el objetivo gana el enfrentamiento. Los colores se mantienen iguales durante todo el enfrentamiento, pero una nueva tirada de apertura determina quién empieza en cada partida. El cubo de doblaje se reinicia centrado en 1 para cada nueva partida.
+\*\*El cubo de doblaje\*\*
 
-\*\*Opciones de partida\*\*
+Los enfrentamientos de más de un punto usan un cubo de doblaje, que empieza centrado en 1. Al inicio de tu turno, antes de lanzar los dados, puedes ofrecer doblar el valor de la partida actual.
 
-\* \*\*Duración del enfrentamiento:\*\* La cantidad de puntos necesarios para ganar el enfrentamiento. Un valor de 1 es una sola partida sin cubo de doblaje (por defecto 1, rango de 1 a 25).
-\* \*\*Dificultad del bot:\*\* Cómo eligen sus movimientos los bots (por defecto Simple, opciones: Simple o Aleatorio).
+El turno inicial no se puede doblar porque sus dados ya se lanzaron para decidir quién empieza.
+
+El oponente debe elegir una de estas respuestas:
+
+\* \*\*Aceptar:\*\* El valor del cubo se duplica. El jugador que acepta toma posesión del cubo y es el único que puede ofrecer el próximo doblaje.
+\* \*\*Rechazar:\*\* La partida actual termina de inmediato. El jugador que ofreció el doblaje gana el valor del cubo previo al aumento propuesto.
+
+Rechazar puede requerir una segunda confirmación cuando la confirmación de acciones riesgosas está activada. Un jugador no puede ofrecer un doblaje cuando el oponente es dueño del cubo, después de haber lanzado los dados, durante una partida Crawford, o cuando aumentar el cubo no puede mejorar el resultado de ese jugador en el enfrentamiento porque el valor actual ya alcanza para ganarlo. Las partidas de un solo punto no usan el cubo.
+
+\*\*La regla Crawford\*\*
+
+Cuando cualquiera de los dos jugadores empieza por primera vez una partida a exactamente un punto de ganar el enfrentamiento, esa partida es la partida Crawford. El cubo de doblaje se desactiva para esa única partida. Si el enfrentamiento continúa, el cubo vuelve a estar disponible en cada partida posterior. PlayAural aplica esta regla automáticamente.
+
+\*\*Opciones personalizables\*\*
+
+\* \*\*Duración del enfrentamiento:\*\* El puntaje objetivo del enfrentamiento, de 1 a 25. El valor por defecto es 1. Una duración de 1 juega una sola partida sin cubo de doblaje.
+\* \*\*Dificultad del bot:\*\* Simple, el valor por defecto, prefiere movimientos tácticos útiles. Aleatorio elige entre los movimientos legales sin esa preferencia táctica.
+
+\*\*Opciones personales de partida\*\*
+
+\* \*\*Anuncios breves:\*\* Usa mensajes de movimiento de ficha más cortos, conservando quién mueve, el origen, el destino, y si una ficha fue capturada, entró desde la barra, o fue sacada del tablero.
+\* \*\*Confirmar acciones riesgosas:\*\* Requiere activar Rechazar una segunda vez dentro de 10 segundos antes de conceder una partida en respuesta a un doblaje.
+
+\*\*Acciones de información\*\*
+
+\* \*\*Estado:\*\* Informa las fichas de cada jugador en la barra, fuera del cuadrante final, y ya sacadas.
+\* \*\*Cuenta de pips:\*\* Informa la distancia total que a cada lado le queda por recorrer para llevar sus fichas a casa y sacarlas. Un conteo más bajo suele ser mejor en una carrera pura, pero no mide las posibilidades de bloqueo o captura.
+\* \*\*Dados:\*\* Informa los dados sin usar del turno actual.
+\* \*\*Movimientos legales:\*\* Abre una lista en vivo de los movimientos permitidos por los dados restantes.
+\* \*\*Cubo:\*\* Informa el valor del cubo, su dueño, y si un doblaje es posible en este momento.
+\* \*\*Consultar puntajes:\*\* Lee el puntaje actual del enfrentamiento. Puntajes detallados abre un panel de puntaje en vivo.
+\* \*\*Ver de quién es el turno\*\* y \*\*Quién está en la mesa:\*\* Informan el jugador activo y la lista de la mesa.
+
+Las acciones de información más usadas están disponibles directamente en los clientes táctiles. Las demás acciones permanecen en el menú de Acciones.
 
 \*\*Atajos de teclado\*\*
 
-\* \*\*Entrar (en cualquier punto de la cuadrícula):\*\* Lanza los dados antes de lanzar, o selecciona y mueve una ficha durante el movimiento.
-\* \*\*Ctrl+Retroceso:\*\* Deselecciona la ficha actualmente seleccionada.
-\* \*\*Ctrl+Abajo o Ctrl+Derecha:\*\* Recorre hacia adelante los objetivos de navegación. Con una ficha seleccionada, recorre los destinos disponibles (primero las fichas sueltas del oponente). Sin selección, recorre los puntos de origen que tienen movimientos legales.
-\* \*\*Ctrl+Arriba o Ctrl+Izquierda:\*\* Recorre hacia atrás los objetivos de navegación.
-\* \*\*Shift+D:\*\* Ofrecer un doblaje antes de lanzar (solo en juego por enfrentamiento).
-\* \*\*Y:\*\* Aceptar un doblaje ofrecido.
-\* \*\*N:\*\* Rechazar un doblaje ofrecido.
-\* \*\*U:\*\* Deshacer el último submovimiento del turno actual.
-\* \*\*E:\*\* Leer la cantidad de fichas en la barra y ya retiradas.
-\* \*\*P:\*\* Leer el conteo de pips de ambos jugadores.
-\* \*\*D:\*\* Leer el estado del cubo de doblaje.
-\* \*\*S:\*\* Leer la puntuación actual del enfrentamiento.
-\* \*\*Shift+S:\*\* Abrir la puntuación detallada del enfrentamiento.
-\* \*\*C:\*\* Leer los dados restantes del turno actual.
+\* \*\*Entrar sobre un punto del tablero:\*\* Lanza los dados antes de mover, selecciona una ficha, o elige un destino.
+\* \*\*R:\*\* Lanza los dados al inicio de tu turno.
+\* \*\*Ctrl+Retroceso:\*\* Deselecciona la ficha actual.
+\* \*\*Ctrl+Abajo o Ctrl+Derecha:\*\* Recorre hacia adelante los puntos de origen legales, o los destinos legales después de seleccionar una ficha. Las fichas sueltas del oponente se ofrecen primero.
+\* \*\*Ctrl+Arriba o Ctrl+Izquierda:\*\* Recorre hacia atrás las mismas opciones.
+\* \*\*Shift+D:\*\* Ofrece un doblaje antes de lanzar los dados.
+\* \*\*Y:\*\* Acepta un doblaje ofrecido.
+\* \*\*N:\*\* Rechaza un doblaje ofrecido.
+\* \*\*U:\*\* Deshace el último submovimiento del turno actual.
+\* \*\*E:\*\* Lee el estado de las fichas.
+\* \*\*P:\*\* Lee ambas cuentas de pips.
+\* \*\*D:\*\* Lee el cubo de doblaje.
+\* \*\*S:\*\* Lee el puntaje del enfrentamiento.
+\* \*\*Shift+S:\*\* Abre los puntajes detallados.
+\* \*\*C:\*\* Lee los dados restantes.
+\* \*\*M:\*\* Abre Movimientos legales.
+
+\*\*Estrategia para principiantes\*\*
+
+Trata de no dejar fichas sueltas al alcance fácil del oponente. Dos o más fichas en un mismo punto lo hacen seguro para que nadie caiga ahí. Los bloqueos son especialmente valiosos cuando retrasan una ficha del oponente que intenta salir de tu cuadrante final.
+
+Cuando tengas una ficha en la barra, primero fíjate en qué puntos de entrada están abiertos. En una carrera donde ya no es posible ningún contacto, usa la cuenta de pips para comparar quién va adelante. Al sacar fichas, considera toda la tirada antes de elegir la primera ficha, porque un orden puede usar más dados que otro.

--- a/server/locales/es/backgammon.ftl
+++ b/server/locales/es/backgammon.ftl
@@ -8,7 +8,10 @@ backgammon-color-white = blanco
 
 # Inicio de la partida
 backgammon-game-started = { $red } juega con rojo, { $white } juega con blanco.
+backgammon-game-started-you-red = Juegas con rojo. { $opponent } juega con blanco.
+backgammon-game-started-you-white = Juegas con blanco. { $opponent } juega con rojo.
 backgammon-opening-roll = Tirada inicial: { $red } saca { $red_die }, { $white } saca { $white_die }.
+backgammon-opening-roll-you = Tirada inicial: Sacas { $your_die }, { $opponent } saca { $opponent_die }.
 backgammon-opening-tie = Ambos sacaron { $die }, se vuelve a lanzar.
 backgammon-opening-winner-you = Empiezas tú con { $die1 } y { $die2 }.
 backgammon-opening-winner-player = { $player } empieza con { $die1 } y { $die2 }.
@@ -24,58 +27,58 @@ backgammon-no-moves-player = { $player } no tiene movimientos legales, así que 
 # Comentario breve de movimiento
 backgammon-brief-move-normal = { $is_self ->
     [yes] Tú: { $src } a { $dest }.
-    *[no] { $player }: { $src } a { $dest }.
+   *[no] { $player }: { $src } a { $dest }.
 }
 backgammon-brief-move-hit = { $is_self ->
     [yes] Tú: { $src } a { $dest }, capturas a { $opponent }.
     [spectator] { $player }: { $src } a { $dest }, captura a { $opponent }.
-    *[no] { $player }: { $src } a { $dest }, te captura.
+   *[no] { $player }: { $src } a { $dest }, te captura.
 }
 backgammon-brief-move-bar = { $is_self ->
     [yes] Tú: barra a { $dest }.
-    *[no] { $player }: barra a { $dest }.
+   *[no] { $player }: barra a { $dest }.
 }
 backgammon-brief-move-bar-hit = { $is_self ->
     [yes] Tú: barra a { $dest }, capturas a { $opponent }.
     [spectator] { $player }: barra a { $dest }, captura a { $opponent }.
-    *[no] { $player }: barra a { $dest }, te captura.
+   *[no] { $player }: barra a { $dest }, te captura.
 }
 backgammon-brief-move-bearoff = { $is_self ->
     [yes] Tú: sacas de { $src }.
-    *[no] { $player }: saca de { $src }.
+   *[no] { $player }: saca de { $src }.
 }
 
 # Comentario detallado de movimiento
 backgammon-verbose-move-normal = { $is_self ->
     [yes] Mueves una ficha del punto { $src } al punto { $dest }.
-    *[no] { $player } mueve una ficha del punto { $src } al punto { $dest }.
+   *[no] { $player } mueve una ficha del punto { $src } al punto { $dest }.
 } { $src_count ->
     [0] El punto { $src } ahora está vacío, { $dest_count } en el punto { $dest }.
-    *[other] { $src_count } ahora en el punto { $src }, { $dest_count } en el punto { $dest }.
+   *[other] { $src_count } ahora en el punto { $src }, { $dest_count } en el punto { $dest }.
 }
 backgammon-verbose-move-hit = { $is_self ->
     [yes] Mueves una ficha del punto { $src } y capturas la ficha de { $opponent } en el punto { $dest }.
     [spectator] { $player } mueve una ficha del punto { $src } y captura la ficha de { $opponent } en el punto { $dest }.
-    *[no] { $player } mueve una ficha del punto { $src } y captura tu ficha en el punto { $dest }.
+   *[no] { $player } mueve una ficha del punto { $src } y captura tu ficha en el punto { $dest }.
 } { $src_count ->
     [0] El punto { $src } ahora está vacío.
-    *[other] Quedan { $src_count } en el punto { $src }.
+   *[other] Quedan { $src_count } en el punto { $src }.
 }
 backgammon-verbose-move-bar = { $is_self ->
     [yes] Entras desde la barra al punto { $dest }.
-    *[no] { $player } entra desde la barra al punto { $dest }.
+   *[no] { $player } entra desde la barra al punto { $dest }.
 } Ahora hay { $dest_count } en el punto { $dest }.
 backgammon-verbose-move-bar-hit = { $is_self ->
     [yes] Entras desde la barra y capturas la ficha de { $opponent } en el punto { $dest }.
     [spectator] { $player } entra desde la barra y captura la ficha de { $opponent } en el punto { $dest }.
-    *[no] { $player } entra desde la barra y captura tu ficha en el punto { $dest }.
+   *[no] { $player } entra desde la barra y captura tu ficha en el punto { $dest }.
 }
 backgammon-verbose-move-bearoff = { $is_self ->
     [yes] Sacas una ficha del punto { $src }.
-    *[no] { $player } saca una ficha del punto { $src }.
+   *[no] { $player } saca una ficha del punto { $src }.
 } { $src_count ->
     [0] El punto { $src } ahora está vacío.
-    *[other] Quedan { $src_count } en el punto { $src }.
+   *[other] Quedan { $src_count } en el punto { $src }.
 }
 
 # Doblaje
@@ -96,6 +99,7 @@ backgammon-point-occupied-selected-bearoff = { $point } { $color }, { $count } s
 
 # Etiquetas de acción
 backgammon-label-double = Doblar
+backgammon-label-roll = Lanzar dados
 backgammon-label-undo = Deshacer
 backgammon-label-deselect = Deseleccionar
 backgammon-label-next-destination = Siguiente destino
@@ -117,15 +121,33 @@ backgammon-bar-entry-blocked = No puedes entrar en el punto { $point }; está bl
 backgammon-no-die-for-bar-entry = Ninguno de tus dados restantes ({ $dice }) te permite entrar en el punto { $point }.
 backgammon-no-die-for-destination = Ninguno de tus dados restantes ({ $dice }) mueve del punto { $src } al punto { $dest }.
 backgammon-must-use-forced-die = Debes usar { $dice } ahora porque el backgammon requiere usar ambos dados cuando sea posible, o el dado más alto cuando solo se pueda jugar uno.
+backgammon-move-would-waste-die = Ese movimiento te impediría usar tantos dados como exigen las reglas. Elige otro movimiento legal.
 backgammon-bearoff-not-home = Todavía no puedes sacar fichas. Fichas fuera de tu cuadrante final: { $outside }. Fichas en la barra: { $bar }. Primero lleva todas tus fichas a los puntos 1 al 6 y despeja la barra.
+backgammon-bearoff-outside-home-point = El punto { $point } está fuera de tu cuadrante final. Solo pueden sacarse las fichas de los puntos 1 al 6.
 backgammon-bearoff-blocked = No puedes sacar del punto { $point } con un { $die }, porque hay fichas en tu punto { $blocking_point }.
 backgammon-bearoff-no-die = No puedes sacar del punto { $point } con los dados que te quedan ({ $die }).
-backgammon-move-would-waste-die = Ese movimiento te impediría usar tantos dados como exigen las reglas. Elige otro movimiento legal.
 backgammon-nothing-to-undo = No hay nada que deshacer.
+backgammon-undo-move = { $listener ->
+    [actor] Deshaces tu movimiento de { $source } a { $destination }.
+   *[observer] { $player } deshace su movimiento de { $source } a { $destination }.
+}
+backgammon-undo-hit = { $listener ->
+    [actor] Deshaces tu movimiento de { $source } a { $destination } y restauras la ficha de { $opponent }.
+    [target] { $player } deshace su movimiento de { $source } a { $destination } y restaura tu ficha.
+   *[observer] { $player } deshace su movimiento de { $source } a { $destination } y restaura la ficha de { $opponent }.
+}
+backgammon-selection-cleared = Se canceló la selección de ficha.
+backgammon-no-selection = No hay ninguna ficha seleccionada.
 backgammon-cannot-double = No puedes doblar en este momento.
+backgammon-double-single-game = El cubo de doblaje no se usa en una partida individual.
+backgammon-double-crawford = Esta es la partida Crawford, así que el cubo de doblaje no está disponible.
+backgammon-double-dead-cube = Ya ganarías el enfrentamiento si ganas con el valor actual del cubo, así que el cubo está muerto para ti y no se puede doblar.
+backgammon-double-cube-owned = El cubo es propiedad de tu oponente, así que solo esa persona puede ofrecer el próximo doblaje.
+backgammon-double-before-roll-only = Solo puedes ofrecer un doblaje al inicio de tu turno, antes de lanzar los dados.
 backgammon-cannot-undo = No hay nada que deshacer.
 backgammon-not-doubling-phase = No hay ningún doblaje que responder.
 backgammon-need-roll-first = Debes lanzar los dados antes de mover una ficha.
+backgammon-roll-before-moving-only = Solo puedes lanzar los dados al inicio de tu turno, antes de mover.
 backgammon-confirm-drop-double = Rechazar concede esta partida al valor actual del cubo. Presiona Rechazar de nuevo dentro de { $seconds } segundos para confirmar.
 
 # Atajos de información
@@ -133,35 +155,85 @@ backgammon-check-status = Estado
 backgammon-check-cube = Cubo
 backgammon-check-pip = Cuenta de pips
 backgammon-check-dice = Dados
-backgammon-status = Rojo — barra: { $bar_red }, fuera del cuadrante final: { $outside_red }, fichas sacadas: { $off_red }. Blanco — barra: { $bar_white }, fuera del cuadrante final: { $outside_white }, fichas sacadas: { $off_white }.
-backgammon-dice = { $dice }
+backgammon-check-legal-moves = Movimientos legales
+backgammon-status = { $red_self ->
+    [yes] Tú, Rojo
+   *[no] { $red }, Rojo
+} — barra: { $bar_red }, fuera del cuadrante final: { $outside_red }, fichas sacadas: { $off_red }. { $white_self ->
+    [yes] Tú, Blanco
+   *[no] { $white }, Blanco
+} — barra: { $bar_white }, fuera del cuadrante final: { $outside_white }, fichas sacadas: { $off_white }.
+backgammon-dice = { $is_self ->
+    [yes] Tus dados restantes: { $dice }.
+   *[no] Dados restantes de { $player }: { $dice }.
+}
 backgammon-dice-none = Sin dados.
+backgammon-no-dice-list = ninguno
 backgammon-cube-status = Cubo en { $value }. { $owner ->
     [center] Centrado, cualquier jugador puede doblar.
-    *[other] Propiedad de { $owner }.
+    [self] Eres dueño del cubo.
+   *[other] Propiedad de { $owner }.
 } { $can_double ->
     [yes] El doblaje está disponible ahora.
     [crawford] Esta es una partida Crawford, no se permite doblar.
-    *[no] El doblaje no está disponible en este momento.
+    [dead] El cubo está muerto para el jugador en turno porque su valor ya alcanza para ganar el enfrentamiento.
+   *[no] El doblaje no está disponible en este momento.
 }
 backgammon-cube-no-match = No hay cubo de doblaje en partidas individuales.
-backgammon-double-single-game = El cubo de doblaje no se usa en una partida individual.
-backgammon-double-cube-owned = El cubo es propiedad de tu oponente, así que solo esa persona puede ofrecer el próximo doblaje.
-backgammon-double-crawford = Esta es la partida Crawford, así que el cubo de doblaje no está disponible.
-backgammon-double-before-roll-only = Solo puedes ofrecer un doblaje al inicio de tu turno, antes de lanzar los dados.
-backgammon-pip-count = Pips del rojo: { $red_pip }. Pips del blanco: { $white_pip }.
-backgammon-match-score-line = { $player }: { $score } de { $match_length }.
+backgammon-pip-count = { $red_self ->
+    [yes] Tú, Rojo
+   *[no] { $red }, Rojo
+}: { $red_pip } pips. { $white_self ->
+    [yes] Tú, Blanco
+   *[no] { $white }, Blanco
+}: { $white_pip } pips.
+backgammon-match-score-line = { $is_self ->
+    [yes] Tú: { $score } de { $match_length }.
+   *[no] { $player }: { $score } de { $match_length }.
+}
 backgammon-match-score-cube-line = Cubo: { $cube }.
 
-# Puntuación
+# Estado de movimientos legales
+backgammon-legal-moves-awaiting-roll = { $is_self ->
+    [yes] Debes lanzar los dados antes de que haya movimientos de ficha disponibles.
+   *[no] { $player } debe lanzar los dados antes de que haya movimientos de ficha disponibles.
+}
+backgammon-legal-moves-awaiting-double-response = { $is_self ->
+    [yes] Debes aceptar o rechazar el doblaje ofrecido antes de que la partida continúe.
+   *[no] { $player } debe aceptar o rechazar el doblaje ofrecido antes de que la partida continúe.
+}
+backgammon-legal-moves-none = { $is_self ->
+    [yes] No tienes ningún movimiento de ficha legal.
+   *[no] { $player } no tiene ningún movimiento de ficha legal.
+}
+backgammon-move-source-bar = barra
+backgammon-move-destination-off = fuera del tablero
+backgammon-legal-move-line = { $is_self ->
+    [yes] Tú: { $source } a { $destination } usando { $die }
+   *[no] { $player }: { $source } a { $destination } usando { $die }
+}{ $hit ->
+    [yes] , capturando una ficha suelta.
+   *[no] .
+}
+
 backgammon-wins-game-you = Ganas { $points } { $points ->
     [one] punto
    *[other] puntos
-}.
+}. { $result ->
+    [single] Victoria normal con el cubo en { $cube }.
+    [gammon] Gammon con el cubo en { $cube }.
+    [backgammon] Backgammon con el cubo en { $cube }.
+   *[drop] Tu oponente rechazó el doblaje con el cubo en { $cube }.
+}
 backgammon-wins-game-player = { $player } gana { $points } { $points ->
     [one] punto
    *[other] puntos
-}.
+}. { $result ->
+    [single] Victoria normal con el cubo en { $cube }.
+    [gammon] Gammon con el cubo en { $cube }.
+    [backgammon] Backgammon con el cubo en { $cube }.
+   *[drop] Su oponente rechazó el doblaje con el cubo en { $cube }.
+}
 backgammon-new-game = Comenzando la partida { $number }.
 backgammon-match-winner-you = ¡Ganas el enfrentamiento!
 backgammon-match-winner-player = ¡{ $player } gana el enfrentamiento!

--- a/server/locales/es/main.ftl
+++ b/server/locales/es/main.ftl
@@ -323,6 +323,7 @@ action-table-full = La mesa está llena.
 action-start-needs-more-players = No se puede iniciar. Jugadores activos: { $current }. Mínimo requerido: { $minimum }.
 action-start-has-too-many-players = No se puede iniciar. Jugadores activos: { $current }. Máximo permitido: { $maximum }.
 action-start-requires-exact-players = No se puede iniciar. Jugadores activos: { $current }. Se requieren exactamente: { $required }.
+action-start-needs-human-player = No se puede iniciar solo con bots. Al menos un humano debe participar como jugador. Cambia de espectador a jugador; si la mesa está llena, primero elimina a un bot.
 action-no-bots = No hay bots para quitar.
 action-bots-cannot = Los bots no pueden hacer esto.
 action-no-scores = Aún no hay puntuaciones disponibles.


### PR DESCRIPTION
Hello @Daoductrung. This translates everything added or changed in
Spanish following the Backgammon rules and accessibility overhaul.

Since this round touched several keys that gained new select variants
(result, owner, can_double) rather than just new plain keys, I paid
particular attention to matching the exact variant strings the code
constructs -- I traced result=/owner=/can_double= directly in
server/games/backgammon/game.py to confirm "single"/"gammon"/
"backgammon"/"drop", "center"/"self", and "crawford"/"dead" all match
the Spanish variant keys literally.

I also noticed the Backgammon beginner guide was substantially
rewritten (88 to 156 lines) and translated the new version in full
rather than leaving the old one in place; it's structurally identical
to the English source (16 headings, 36 bullets).

Both changelog entries since my last PR ("Tuesday 25 August 2026" was
already in from last time; "Thursday 27 August 2026" was missing) are
now translated, with matching bullet counts.

Verified with server/tools/compare_locales.py: no missing, obsolete,
duplicate, or variable/attribute mismatches. Parsed both .ftl files
with fluent.syntax (0 corrupted entries).

Let me know if anything needs adjustment.